### PR TITLE
add paroxython

### DIFF
--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1301,6 +1301,10 @@ PROJECTS = [
         mypy_cmd="{mypy} .",
     ),
     Project(
+        location="https://github.com/laowantong/paroxython.git",
+        mypy_cmd="{mypy} paroxython",
+    ),
+    Project(
         # broken by changes to `--custom-typeshed-dir`
         location="https://github.com/Akuli/porcupine.git",
         mypy_cmd="{mypy} porcupine more_plugins",

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1303,6 +1303,7 @@ PROJECTS = [
     Project(
         location="https://github.com/laowantong/paroxython.git",
         mypy_cmd="{mypy} paroxython",
+        expected_success=True,
     ),
     Project(
         # broken by changes to `--custom-typeshed-dir`

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1225,6 +1225,11 @@ PROJECTS = [
         mypy_cmd="{mypy} --config python/mypy.ini python/pyspark",
         expected_success=True,
     ),
+    Project(
+        location="https://github.com/laowantong/paroxython.git",
+        mypy_cmd="{mypy} paroxython",
+        expected_success=True,
+    ),
     # failures expected...
     Project(
         location="https://github.com/pyppeteer/pyppeteer.git",
@@ -1299,11 +1304,6 @@ PROJECTS = [
     Project(
         location="https://github.com/mikeshardmind/SinbadCogs.git",
         mypy_cmd="{mypy} .",
-    ),
-    Project(
-        location="https://github.com/laowantong/paroxython.git",
-        mypy_cmd="{mypy} paroxython",
-        expected_success=True,
     ),
     Project(
         # broken by changes to `--custom-typeshed-dir`


### PR DESCRIPTION
When reviewing https://github.com/python/typeshed/pull/5248, I did a Github code search for projects that contain `import docopt  # type: ignore`. I had never heard of `paroxython` before, but I chose it because it's quite big and the latest commit is not too long ago.