### PR TITLE
move porcupine out of failures expected section

### DIFF
--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1236,6 +1236,10 @@ PROJECTS = [
         mypy_cmd="{mypy} paroxython",
         expected_success=True,
     ),
+    Project(
+        location="https://github.com/Akuli/porcupine.git",
+        mypy_cmd="{mypy} porcupine more_plugins",
+    ),
     # failures expected...
     Project(
         location="https://github.com/pyppeteer/pyppeteer.git",
@@ -1310,11 +1314,6 @@ PROJECTS = [
     Project(
         location="https://github.com/mikeshardmind/SinbadCogs.git",
         mypy_cmd="{mypy} .",
-    ),
-    Project(
-        # broken by changes to `--custom-typeshed-dir`
-        location="https://github.com/Akuli/porcupine.git",
-        mypy_cmd="{mypy} porcupine more_plugins",
     ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1239,6 +1239,7 @@ PROJECTS = [
     Project(
         location="https://github.com/Akuli/porcupine.git",
         mypy_cmd="{mypy} porcupine more_plugins",
+        expected_success=True,
     ),
     # failures expected...
     Project(


### PR DESCRIPTION
Porcupine no longer bundles a custom typeshed in a git submodule.