### PR TITLE
Add mypy-protobuf project to mypy_primer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ htmlcov
 
 # General
 .DS_Store
+
+# Editor temp files
+.*.swp

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1345,6 +1345,12 @@ PROJECTS = [
         mypy_cmd="{mypy} rotkehlchen/ tools/data_faker",
         pip_cmd="{pip} install types-requests",
     ),
+    Project(
+        location="https://github.com/dropbox/mypy-protobuf",
+        mypy_cmd="{mypy} mypy_protobuf/",
+        pip_cmd="{pip} install types-protobuf",
+        expected_success=True,
+    ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})
 


### PR DESCRIPTION
This only runs mypy on the codegen plugin itself, not on the output of the plugin.

Running on the output of the plugin would be wonderful, but requires a bit of work
- Factoring in mypy-protobuf's tests to commit the `.pyi` files (currently the testsuite generates them)
- Allowing mypy_primer to have multiple mypy_cmds on one project

I might loop back around to trying to make that possible.