### PR TITLE
Include python-sop

### DIFF
--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1520,7 +1520,7 @@ PROJECTS = [
         pip_cmd="{pip} install pytest pproxy",
     ),
     Project(
-        locaion="https://gitlab.com/dkg/python-sop",
+        location="https://gitlab.com/dkg/python-sop",
         mypy_cmd="{mypy} --strict sop",
     ),
 ]

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1521,7 +1521,8 @@ PROJECTS = [
     ),
     Project(
         locaion="https://gitlab.com/dkg/python-sop",
-        mypy_cmd="{mypy} --strict sop"
+        mypy_cmd="{mypy} --strict sop",
+    ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})
 

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1519,6 +1519,9 @@ PROJECTS = [
         mypy_cmd="{mypy}",
         pip_cmd="{pip} install pytest pproxy",
     ),
+    Project(
+        locaion="https://gitlab.com/dkg/python-sop",
+        mypy_cmd="{mypy} --strict sop"
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})
 


### PR DESCRIPTION
Would have caught this mypy 0.930 regression: https://ci.debian.net/data/autopkgtest/testing/amd64/p/python-sop/18100014/log.gz

```
sop/__init__.py:224: error: Missing type parameters for generic type "_SubParsersAction"
sop/__init__.py:387: error: Missing type parameters for generic type "_SubParsersAction"
```