### PR TITLE
Let's try `django-stubs`

### DIFF
--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1523,6 +1523,11 @@ PROJECTS = [
         location="https://gitlab.com/dkg/python-sop",
         mypy_cmd="{mypy} --strict sop",
     ),
+    Project(
+        location="https://github.com/typeddjango/django-stubs",
+        mypy_cmd="{mypy} django-stubs mypy_django_plugin",
+        pip_cmd="{pip} install django django-stubs-ext tomli typing-extensions types-pytz types-PyYAML",
+    ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})
 

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1526,7 +1526,10 @@ PROJECTS = [
     Project(
         location="https://github.com/typeddjango/django-stubs",
         mypy_cmd="{mypy} django-stubs mypy_django_plugin",
-        pip_cmd="{pip} install django django-stubs-ext tomli typing-extensions types-pytz types-PyYAML",
+        pip_cmd=(
+            "{pip} install django django-stubs-ext tomli typing-extensions "
+            "types-pytz types-PyYAML"
+        ),
     ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})


### PR DESCRIPTION
Probably it should work even without our `mypy` plugin.
At least our CI check passes without it: https://github.com/typeddjango/django-stubs/blob/master/.pre-commit-config.yaml#L38-L53

P.S. why don't we use `pip install -r requirements`? Why all deps are copied?