### PR TITLE
Add jsonschema libs

### DIFF
--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1567,6 +1567,13 @@ PROJECTS = [
         mypy_cmd="{mypy} src",
         pip_cmd="{pip} install types-jsonschema types-requests",
     ),
+    Project(
+        location="https://github.com/matrix-org/synapse",
+        mypy_cmd="{mypy} synapse",
+        pip_cmd="{pip} install types-bleach types-commonmark types-jsonschema "
+        "types-opentracing types-Pillow types-psycopg2 types-pyOpenSSL types-PyYAML "
+        "types-requests types-setuptools"
+    )
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})
 

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1567,13 +1567,6 @@ PROJECTS = [
         mypy_cmd="{mypy} src",
         pip_cmd="{pip} install types-jsonschema types-requests",
     ),
-    Project(
-        location="https://github.com/matrix-org/synapse",
-        mypy_cmd="{mypy} synapse",
-        pip_cmd="{pip} install types-bleach types-commonmark types-jsonschema "
-        "types-opentracing types-Pillow types-psycopg2 types-pyOpenSSL types-PyYAML "
-        "types-requests types-setuptools",
-    ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})
 

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1372,6 +1372,7 @@ PROJECTS = [
             " @typechecked-files --no-strict-optional"
         ),
         pip_cmd="{pip} install types-PyYAML",
+        expected_success=True,
     ),
     Project(
         location="https://github.com/wntrblm/nox",
@@ -1395,6 +1396,12 @@ PROJECTS = [
         location="https://gitlab.com/cki-project/cki-lib",
         mypy_cmd="{mypy} --strict",
         pip_cmd="{pip} install types-PyYAML types-requests",
+        expected_success=True,
+    ),
+    Project(
+        location="https://github.com/python-jsonschema/check-jsonschema",
+        mypy_cmd="{mypy} src",
+        pip_cmd="{pip} install types-jsonschema types-requests",
         expected_success=True,
     ),
     *(
@@ -1561,11 +1568,6 @@ PROJECTS = [
         location="https://github.com/Rapptz/discord.py",
         mypy_cmd="{mypy} discord",
         pip_cmd="{pip} install types-requests types-setuptools aiohttp",
-    ),
-    Project(
-        location="https://github.com/python-jsonschema/check-jsonschema",
-        mypy_cmd="{mypy} src",
-        pip_cmd="{pip} install types-jsonschema types-requests",
     ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1562,6 +1562,11 @@ PROJECTS = [
         mypy_cmd="{mypy} discord",
         pip_cmd="{pip} install types-requests types-setuptools aiohttp",
     ),
+    Project(
+        location="https://github.com/python-jsonschema/check-jsonschema",
+        mypy_cmd="{mypy} src",
+        pip_cmd="{pip} install types-jsonschema types-requests",
+    ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})
 

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1572,8 +1572,8 @@ PROJECTS = [
         mypy_cmd="{mypy} synapse",
         pip_cmd="{pip} install types-bleach types-commonmark types-jsonschema "
         "types-opentracing types-Pillow types-psycopg2 types-pyOpenSSL types-PyYAML "
-        "types-requests types-setuptools"
-    )
+        "types-requests types-setuptools",
+    ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})
 


### PR DESCRIPTION
I'm adding more info to `types-jsonschema` stubs, and there were two bugs which it would have been nice to catch earlier. Add two users of `types-jsonschema` to the project list.

- [`check-jsonschema`](https://github.com/python-jsonschema/check-jsonschema) (my own work)
- [`synapse`](https://github.com/matrix-org/synapse), who reported and submitted a fix for a `types-jsonschema` bug

@DMRobertson, I don't believe that adding your project to mypy_primer carries any obligation for you or your team, but wanted to give you a heads-up about this.

We can also cut `synapse` and just add `check-jsonschema` if adding it is an issue for someone.