### PR TITLE
Add canonical's cloud-init to projects to check

### DIFF
--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1569,6 +1569,13 @@ PROJECTS = [
         mypy_cmd="{mypy} discord",
         pip_cmd="{pip} install types-requests types-setuptools aiohttp",
     ),
+    Project(
+        location="https://github.com/canonical/cloud-init",
+        mypy_cmd="{mypy} cloudinit/ tests/ tools/",
+        pip_cmd="{pip} install jinja2 pytest "
+        "types-jsonschema types-oauthlib "
+        "types-pyyaml types-requests types-setuptools",
+    ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})
 


### PR DESCRIPTION
The mypy invocation is taken from their tox config, as is the list of typeshed stubs to use.

cc @holmanb , this might interest you as I see you're the @canonical team member who most recently made changes to the mypy config for `cloud-init`. Being in mypy_primer doesn't carry any obligation for you, but it means your project will be used to examine typeshed and mypy changes to assess the impact.
At least, I don't think there's any obligation -- someone please correct me if I'm wrong!