### PR TITLE
pyppeteer: drop hardcoded revision

### DIFF
--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1428,7 +1428,6 @@ PROJECTS = [
         location="https://github.com/pyppeteer/pyppeteer",
         mypy_cmd="{mypy} pyppeteer --config-file tox.ini",
         pip_cmd="{pip} install .",
-        revision="2d27bfdf9b6d0df32e5ebe869b057409042417a8",  # TODO: remove hardcoded revision
     ),
     Project(
         location="https://github.com/pypa/pip",


### PR DESCRIPTION
https://github.com/python/typeshed/pull/8235#issuecomment-1175332658

It's not clear from the comment why this was hardcoded. Let's use this PR to figure out whether we can drop the pin.