### PR TITLE
Update bokeh invocation

### DIFF
--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1647,7 +1647,7 @@ PROJECTS = [
     Project(
         location="https://github.com/bokeh/bokeh",
         mypy_cmd="{mypy} src release",
-        pip_cmd="{pip} install types-boto tornado numpy jinja2",
+        pip_cmd="{pip} install types-boto tornado numpy jinja2 selenium",
     ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})


### PR DESCRIPTION
`bokeh` depends on `selenium`, and `selenium` has shipped with inline type annotations since release 4.1.2