### PR TITLE
(🎁) Support relative `base-dir`

### DIFF
--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -913,6 +913,7 @@ def main() -> None:
 
         if ARGS.base_dir.exists() and ARGS.clear:
             shutil.rmtree(ARGS.base_dir)
+        ARGS.base_dir = ARGS.base_dir.absolute()
         ARGS.base_dir.mkdir(exist_ok=True)
         ARGS.projects_dir = ARGS.base_dir / "projects"
         ARGS.projects_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
So basically I was trying to invoke mypy-primer with `--base-dir ./workdir` but it failed, saying that it couldn't find mypy. I think it was looking for `workdir/new_mypy/venv/bin/mypy`, but the cwd is `./workdir/projects/mypy`.

```
👉 mypy_primer --repo ../mypy --old HEAD -k mypy --base-dir ./workdir

mypy
https://github.com/python/mypy
----------

old mypy
> workdir/old_mypy/venv/bin/mypy --config-file mypy_self_check.ini -p mypy -p mypyc --no-incremental --cache-dir=/dev/null --show-traceback --soft-error-limit ' -1'
UNEXPECTED FAILURE
        /bin/sh: 1: workdir/old_mypy/venv/bin/mypy: not found
----------

new mypy
> workdir/new_mypy/venv/bin/mypy --config-file mypy_self_check.ini -p mypy -p mypyc --no-incremental --cache-dir=/dev/null --show-traceback --soft-error-limit ' -1'
UNEXPECTED FAILURE
        /bin/sh: 1: workdir/new_mypy/venv/bin/mypy: not found
----------

diff
        - /bin/sh: 1: workdir/old_mypy/venv/bin/mypy: not found
        + /bin/sh: 1: workdir/new_mypy/venv/bin/mypy: not found
==========
```
The solution was to invoke it with `--base-dir (pwd)/workdir`(🐟), but this is not straightforward from the output displayed, I think it would be good if this usage was supported.

The change is simply just absolute-ifying the `base-dir`, I'm okay with this, but perhaps there's thing's I'm not accounting for. I'm happy to rework this if there are any alternative suggestions.