### PR TITLE
Allow primer to run on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ htmlcov
 
 # Editor temp files
 .*.swp
+
+# Workspace configurations
+.vscode

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -898,7 +898,7 @@ def parse_options(argv: list[str]) -> argparse.Namespace:
     primer_group.add_argument("--debug", action="store_true", help="print commands as they run")
     primer_group.add_argument(
         "--base-dir",
-        default=Path(tempfile.gettempdir()) / "mypy_primer",
+        default=Path(tempfile.gettempdir() if sys.platform == "win32" else "/tmp") / "mypy_primer",
         type=Path,
         help="dir to store repos and venvs",
     )

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -11,6 +11,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import textwrap
 import time
 import traceback
@@ -892,7 +893,7 @@ def parse_options(argv: list[str]) -> argparse.Namespace:
     primer_group.add_argument("--debug", action="store_true", help="print commands as they run")
     primer_group.add_argument(
         "--base-dir",
-        default=Path("/tmp/mypy_primer"),
+        default=Path(tempfile.gettempdir()) / "mypy_primer",
         type=Path,
         help="dir to store repos and venvs",
     )

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -492,12 +492,7 @@ class PrimerResult:
         new_lines = new_output.splitlines()
         # Hide "note" lines which contain ARGS.base_dir... this hides differences between
         # file paths, e.g., when mypy points to a stub definition.
-
-        if sys.platform == "win32":
-            base_dir = str(ARGS.base_dir).replace("\\", r"\\")
-        else:
-            base_dir = ARGS.base_dir
-        base_dir_re = re.compile(f"{base_dir}.*: note:")
+        base_dir_re = re.compile(f"{re.escape(ARGS.base_dir)}.*: note:")
         old_lines = [line for line in old_lines if not re.search(base_dir_re, line)]
         new_lines = [line for line in new_lines if not re.search(base_dir_re, line)]
         diff = d.compare(old_lines, new_lines)
@@ -764,7 +759,8 @@ async def primer() -> int:
             # - always pass in --no-pretty and --no-error-summary
             concise = result.format_concise()
             if concise:
-                print(concise, "\n")
+                print(concise)
+                print()
         if not retcode and result.diff:
             retcode = 1
     return retcode

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-with open("README.md", "r") as f:
+with open("README.md", "r", encoding="UTF-8") as f:
     long_description = f.read()
 
 setup(

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,6 @@ set -ex
 
 isort --diff --check --quiet .
 black --diff --check --quiet .
-flake8 --max-line-length 100 --ignore E203,W503 $(git ls-files | grep "py$")
+flake8 --max-line-length=100 --ignore=E203,W503 $(git ls-files | grep "py$")
 mypy -m mypy_primer --strict
 python -c 'import mypy_primer'


### PR DESCRIPTION
Fixes the following issue: `FileNotFoundError: [WinError 3] The system cannot find the path specified: 'E:\\tmp\\mypy_primer'`
By using the OS' temp folder.

Fixes the mypy.exe expected location (from `/bin/mypy` to `/scripts/mypy.exe` on windows)

Ensure utf-8 encoding

FIx `--soft-error-limit ' -1'` becomming `--soft-error-limit \' -1\'` error in powershell

Fixed windows backward slashes in path resulting in bad escape regex errors.