### PR TITLE
Fix escape code rendering on Windows + Update typeshed main branch in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ mypy_primer -o diff
 
 See the impact of your risky change with:
 ```
-mypy_primer --repo https://github.com/hauntsaninja/mypy.git --new my_risky_change --old main
+mypy_primer --repo https://github.com/hauntsaninja/mypy.git --new my_risky_change --old master
 ```
 
 See the impact of your risky typeshed change with:

--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ mypy_primer -o diff
 
 See the impact of your risky change with:
 ```
-mypy_primer --repo https://github.com/hauntsaninja/mypy.git --new my_risky_change --old master
+mypy_primer --repo https://github.com/hauntsaninja/mypy.git --new my_risky_change --old main
 ```
 
 See the impact of your risky typeshed change with:
 ```
-mypy_primer --custom-typeshed-repo ~/dev/typeshed --new-typeshed my_risky_change --old-typeshed master --new v0.782 --old v0.782 -o concise
+mypy_primer --custom-typeshed-repo ~/dev/typeshed --new-typeshed my_risky_change --old-typeshed main --new v0.782 --old v0.782 -o concise
 ```
 
 Filter to projects you care about:

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1726,37 +1726,6 @@ PROJECTS = [
         mypy_cmd="{mypy} src",
         pip_cmd="{pip} install pydantic beartype hydra-core",
     ),
-    Project(
-        location="https://github.com/certbot/certbot",
-        mypy_cmd="{mypy} .",
-        pip_cmd="{pip} install .",
-    ),
-    Project(
-        location="https://github.com/ankitects/anki",
-        mypy_cmd="{mypy} .",
-        pip_cmd="{pip} install types-pywin32",
-    ),
-    Project(
-        location="https://github.com/guardicore/monkey",
-        mypy_cmd="{mypy} .",
-        pip_cmd="{pip} install types-pywin32",
-    ),
-    Project(
-        location="https://github.com/twisted/twisted",
-        mypy_cmd="{mypy} .",
-        pip_cmd="{pip} install types-pywin32",
-    ),
-    Project(
-        location="https://github.com/Flexget/Flexget",
-        mypy_cmd="{mypy} .",
-        pip_cmd="{pip} install types-pywin32",
-    ),
-    Project(
-        location="https://github.com/mhammond/pywin32",
-        mypy_cmd="{mypy} com/win32com com/win32comext win32/Lib isapi --python-version=3.7"
-        " --explicit-package-bases",
-        pip_cmd="{pip} install pyopengl Pyro4 types-pywin32",
-    ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})
 

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -58,7 +58,7 @@ class Style(str, Enum):
 
 
 def strip_colour_code(text: str) -> str:
-    return re.sub(r"\\033\[\d+?m", "", text)
+    return re.sub("\033\\[\\d+?m", "", text)
 
 
 def debug_print(obj: Any) -> None:
@@ -1725,6 +1725,37 @@ PROJECTS = [
         location="https://github.com/mit-ll-responsible-ai/hydra-zen",
         mypy_cmd="{mypy} src",
         pip_cmd="{pip} install pydantic beartype hydra-core",
+    ),
+    Project(
+        location="https://github.com/certbot/certbot",
+        mypy_cmd="{mypy} .",
+        pip_cmd="{pip} install .",
+    ),
+    Project(
+        location="https://github.com/ankitects/anki",
+        mypy_cmd="{mypy} .",
+        pip_cmd="{pip} install types-pywin32",
+    ),
+    Project(
+        location="https://github.com/guardicore/monkey",
+        mypy_cmd="{mypy} .",
+        pip_cmd="{pip} install types-pywin32",
+    ),
+    Project(
+        location="https://github.com/twisted/twisted",
+        mypy_cmd="{mypy} .",
+        pip_cmd="{pip} install types-pywin32",
+    ),
+    Project(
+        location="https://github.com/Flexget/Flexget",
+        mypy_cmd="{mypy} .",
+        pip_cmd="{pip} install types-pywin32",
+    ),
+    Project(
+        location="https://github.com/mhammond/pywin32",
+        mypy_cmd="{mypy} com/win32com com/win32comext win32/Lib isapi --python-version=3.7"
+        " --explicit-package-bases",
+        pip_cmd="{pip} install pyopengl Pyro4 types-pywin32",
     ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})


### PR DESCRIPTION
Demo:
![image](https://user-images.githubusercontent.com/1350584/205431270-3bdffef6-c596-43a8-9bd7-8125aa754d2d.png)
\+ centralized the platform-specific constants under a single check.

\+ Updated the `strip_colour_code` regex:
- Standardize `\033` vs `\x1b`
- Regex matches codes more tightly


I've also updated the name of the default branch for typeshed in the doc cuz I noticed that.