### PR TITLE
Add `pwndbg`

### DIFF
--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1793,6 +1793,11 @@ PROJECTS = [
         ),
         cost=30,
     ),
+    Project(
+        location="https://github.com/pwndbg/pwndbg",
+        mypy_cmd="{mypy} pwndbg",
+        pip_cmd="{pip} install types-gdb"
+    )
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})
 

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1796,7 +1796,7 @@ PROJECTS = [
     Project(
         location="https://github.com/pwndbg/pwndbg",
         mypy_cmd="{mypy} pwndbg",
-        pip_cmd="{pip} install types-gdb"
+        pip_cmd="{pip} install types-gdb",
     ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})

--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1797,7 +1797,7 @@ PROJECTS = [
         location="https://github.com/pwndbg/pwndbg",
         mypy_cmd="{mypy} pwndbg",
         pip_cmd="{pip} install types-gdb"
-    )
+    ),
 ]
 assert len(PROJECTS) == len({p.name for p in PROJECTS})
 


### PR DESCRIPTION
This gets us some coverage for our `types-gdb` stubs in typeshed. The project is currently working towards getting type-checking errors down to zero, and may be submitting more typeshed PRs for our `gdb` stubs in the future: https://github.com/pwndbg/pwndbg/issues/1475.

There are lots of other dependencies installed if you run `pip install dev-requirements.txt` in a virtual environment inside the `pwndbg` repo, but `types-gdb` seems to be the only one that's relevant to type-checking.