### PR TITLE
Add `meson`

### DIFF
--- a/mypy_primer.py
+++ b/mypy_primer.py
@@ -1597,6 +1597,12 @@ PROJECTS = [
         pip_cmd="{pip} install types-setuptools types-pywin32 types-python-xlib",
         expected_success=True,
     ),
+    Project(
+        location="https://github.com/mesonbuild/meson",
+        mypy_cmd="./run_mypy.py --mypy {mypy}",
+        pip_cmd="{pip} install types-PyYAML",
+        expected_success=True,
+    ),
     *(
         [
             Project(


### PR DESCRIPTION
Related to #42

See https://github.com/mesonbuild/meson/pull/10994 -- this presumably could have caught https://github.com/python/mypy/issues/12483


(I just merged code into meson that allows passing through the mypy executable and the primer options to our run_mypy.py wrapper, so that this can work. I hope it's not a problem to use our script -- it encodes the names of each file that we have passing mypy, so the run is successful.)