### PR TITLE
add rudimentary pyright support

### DIFF
--- a/mypy_primer/globals.py
+++ b/mypy_primer/globals.py
@@ -9,10 +9,11 @@ import mypy_primer.utils
 
 @dataclass
 class _Args:
-    # mypy group
+    # type checker group
     new: str | None
     old: str | None
     repo: str | None
+    type_checker: str
     mypyc_compile_level: int | None
 
     custom_typeshed_repo: str
@@ -70,6 +71,12 @@ def parse_options(argv: list[str]) -> _Args:
             "old type checker version, defaults to latest tag "
             "(pypi version, anything commit-ish, or isoformatted date)"
         ),
+    )
+    type_checker_group.add_argument(
+        "--type-checker",
+        default="mypy",
+        choices=["mypy", "pyright"],
+        help="type checker to use",
     )
     type_checker_group.add_argument(
         "--repo",

--- a/mypy_primer/type_checker.py
+++ b/mypy_primer/type_checker.py
@@ -65,6 +65,25 @@ async def setup_mypy(
     return mypy_exe
 
 
+async def setup_pyright(
+    pyright_dir: Path,
+    revision_like: RevisionLike,
+    *,
+    repo: str | None,
+) -> Path:
+    pyright_dir.mkdir(exist_ok=True)
+
+    if repo is None:
+        repo = "https://github.com/microsoft/pyright"
+    repo_dir = await ensure_repo_at_revision(repo, pyright_dir, revision_like)
+
+    # Can you tell I don't really work with JS? This is hopefully enough npms to get things working
+    await run(["npm", "install"], cwd=repo_dir)
+    await run(["npm", "install"], cwd=repo_dir / "packages" / "pyright")
+    await run(["npm", "run", "build"], cwd=repo_dir / "packages" / "pyright")
+    return repo_dir / "packages" / "pyright" / "index.js"
+
+
 async def setup_typeshed(parent_dir: Path, *, repo: str, revision_like: RevisionLike) -> Path:
     if parent_dir.exists():
         shutil.rmtree(parent_dir)


### PR DESCRIPTION
This pull request follows up on a bunch of refactoring from earlier today.

This is enough to make basic commands like `mypy_primer --type-checker pyright --old a08f716f9 --debug -k hauntsaninja/pyp` do something.

There's still basic stuff left to be done. For instance, get pyright to use the project virtual environment and custom typeshed dir and alter project list logic for pyright's needs.