### PR TITLE
Update AutoSplit name and typed dependencies

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -805,12 +805,12 @@ def get_projects() -> list[Project]:
             mypy_cost=30,
         ),
         Project(
-            location="https://github.com/Toufool/Auto-Split",
+            location="https://github.com/Toufool/AutoSplit",
             mypy_cmd="{mypy} src",
-            pyright_cmd="{pyright}",
+            pyright_cmd="{pyright} src",
             pip_cmd=(
-                "{pip} install certifi ImageHash numpy packaging PyQt6 "
-                "types-d3dshot types-keyboard types-Pillow types-psutil types-PyAutoGUI "
+                "{pip} install certifi ImageHash numpy packaging PyWinCtl PySide6-Essentials "
+                "winsdk types-D3DShot types-keyboard types-Pillow types-psutil types-PyAutoGUI "
                 "types-pyinstaller types-pywin32 types-requests types-toml"
             ),
         ),


### PR DESCRIPTION
(originally meant as `Update Avasam/Auto-Split to Toufool/AutoSplit`, but it looks like you already caught that).

A while ago development has moved back upstream and the owner stood down as a maintainer, giving me full access. Repo name was updated to the correct un-hyphenated name. And a few notable typed library changes have been made.

I also updated the pyright_cmd so it has a tiny bit less crawling to do.