### PR TITLE
Make the projects be their own `repr`!

### DIFF
--- a/mypy_primer/main.py
+++ b/mypy_primer/main.py
@@ -112,7 +112,11 @@ def select_projects() -> list[Project]:
     if ARGS.local_project:
         return [Project.from_location(ARGS.local_project)]
 
-    project_iter: Iterator[Project] = iter(p for p in get_projects())
+    project_iter: Iterator[Project] = iter(
+        p
+        for p in get_projects()
+        if not (p.min_python_version and sys.version_info < p.min_python_version)
+    )
     if ARGS.type_checker == "pyright":
         project_iter = iter(p for p in project_iter if p.pyright_cmd is not None)
     if ARGS.project_selector:

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -340,7 +340,7 @@ class PrimerResult:
             ret += (
                 f": typechecking got {runtime_ratio:.2f}x {speed} "
                 f"({self.old_result.runtime:.1f}s -> {self.new_result.runtime:.1f}s)\n"
-                f"(Performance measurements are based on a single noisy sample)"
+                "(Performance measurements are based on a single noisy sample)"
             )
         if self.diff:
             ret += "\n" + self.diff

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -34,6 +34,24 @@ class Project:
     pyright_cmd: str | None = None
     expected_pyright_success: bool = False
 
+    # custom __repr__ that omits defaults.
+    def __repr__(self) -> str:
+        result = f"Project(location={self.location!r}, mypy_cmd={self.mypy_cmd!r}"
+        if self.pyright_cmd:
+            result += f", pyright_cmd={self.pyright_cmd!r}"
+        if self.pip_cmd:
+            result += f", pip_cmd={self.pip_cmd!r}"
+        if self.expected_mypy_success:
+            result += f", expected_mypy_success={self.expected_mypy_success!r}"
+        if self.expected_pyright_success:
+            result += f", expected_pyright_success={self.expected_pyright_success!r}"
+        if self.mypy_cost != 3:
+            result += f", mypy_cost={self.mypy_cost!r}"
+        if self.revision:
+            result += f", revision={self.revision!r}"
+        result += ")"
+        return result
+
     @property
     def name(self) -> str:
         return Path(self.location).name

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -19,7 +19,6 @@ from mypy_primer.git_utils import ensure_repo_at_revision
 from mypy_primer.globals import ctx
 from mypy_primer.utils import BIN_DIR, Style, debug_print, run
 
-
 extra_dataclass_args = {"kw_only": True} if sys.version_info >= (3, 10) else {}
 
 

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -20,11 +20,15 @@ from mypy_primer.globals import ctx
 from mypy_primer.utils import BIN_DIR, Style, debug_print, run
 
 
-@dataclass(frozen=True)
+extra_dataclass_args = {"kw_only": True} if sys.version_info >= (3, 10) else {}
+
+
+@dataclass(frozen=True, **extra_dataclass_args)
 class Project:
     location: str
     mypy_cmd: str
     revision: str | None = None
+    min_python_version: tuple[int, int] | None = None
     pip_cmd: str | None = None
     # if expected_success, there is a recent version of mypy which passes cleanly
     expected_mypy_success: bool = False
@@ -49,6 +53,8 @@ class Project:
             result += f", mypy_cost={self.mypy_cost!r}"
         if self.revision:
             result += f", revision={self.revision!r}"
+        if self.min_python_version:
+            result += f", min_python_version={self.min_python_version!r}"
         result += ")"
         return result
 

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import difflib
+import subprocess
 import sys
 
 from mypy_primer.model import Project
@@ -33,11 +34,12 @@ def update_projects(projects: list[Project], check: bool = False) -> None:
                 keep = True
 
     if check:
-        import black
-
-        code = black.format_file_contents(
-            "\n".join(result), fast=False, mode=black.mode.Mode(preview=True, line_length=100)
+        code_proc = subprocess.run(
+            ["black", "-c", "\n".join(result)], capture_output=True, text=True
         )
+        code_proc.check_returncode
+        code = code_proc.stdout
+
         with open(__file__) as f:
             in_file = f.read()
             if in_file != code:

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sys
-
 from mypy_primer.model import Project
 
 # projects to re-enable:

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -771,8 +771,8 @@ def get_projects() -> list[Project]:
             location="https://github.com/caronc/apprise",
             mypy_cmd="{mypy} .",
             pip_cmd=(
-                "{pip} install types-six types-mock cryptography types-requests "
-                " types-Markdown pytest certifi babel"
+                "{pip} install types-six types-mock cryptography types-requests types-Markdown"
+                " pytest certifi babel"
             ),
         ),
         Project(

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -42,8 +42,8 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} pandas",
             pyright_cmd="{pyright} pandas",
             pip_cmd=(
-                "{pip} install numpy types-python-dateutil types-pytz types-PyMySQL "
-                "types-setuptools pytest"
+                "{pip} install numpy types-python-dateutil types-pytz types-PyMySQL"
+                " types-setuptools pytest"
             ),
             expected_mypy_success=True,
             mypy_cost=120,
@@ -155,8 +155,8 @@ def get_projects() -> list[Project]:
                 "{mypy} zerver zilencer zproject tools analytics corporate scripts --platform=linux"
             ),
             pip_cmd=(
-                "{pip} install types-PyYAML types-polib types-redis types-Markdown types-decorator "
-                "types-pytz types-requests types-python-dateutil types-orjson cryptography"
+                "{pip} install types-PyYAML types-polib types-redis types-Markdown types-decorator"
+                " types-pytz types-requests types-python-dateutil types-orjson cryptography"
             ),
             expected_mypy_success=True,
         ),
@@ -170,8 +170,8 @@ def get_projects() -> list[Project]:
             location="https://github.com/yelp/paasta",
             mypy_cmd="{mypy} paasta_tools",
             pip_cmd=(
-                "{pip} install types-retry types-tzlocal types-ujson types-python-dateutil "
-                "types-pytz types-PyYAML types-requests"
+                "{pip} install types-retry types-tzlocal types-ujson types-python-dateutil"
+                " types-pytz types-PyYAML types-requests"
             ),
             expected_mypy_success=True,
         ),
@@ -179,9 +179,9 @@ def get_projects() -> list[Project]:
             location="https://github.com/PrefectHQ/prefect",
             mypy_cmd="{mypy} src",
             pip_cmd=(
-                "{pip} install types-python-dateutil types-requests types-simplejson types-toml "
-                "types-croniter types-PyYAML types-python-slugify types-pytz cryptography "
-                "SQLAlchemy"
+                "{pip} install types-python-dateutil types-requests types-simplejson types-toml"
+                " types-croniter types-PyYAML types-python-slugify types-pytz cryptography"
+                " SQLAlchemy"
             ),
             expected_mypy_success=True,
         ),
@@ -234,8 +234,8 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} freqtrade scripts",
             pyright_cmd="{pyright}",
             pip_cmd=(
-                "{pip} install types-cachetools types-requests types-python-dateutil "
-                "types-tabulate types-filelock"
+                "{pip} install types-cachetools types-requests types-python-dateutil types-tabulate"
+                " types-filelock"
             ),
             expected_mypy_success=True,
         ),
@@ -434,8 +434,8 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/awslabs/sockeye",
             mypy_cmd=(
-                "{mypy} --ignore-missing-imports --follow-imports=silent"
-                " @typechecked-files --no-strict-optional"
+                "{mypy} --ignore-missing-imports --follow-imports=silent @typechecked-files"
+                " --no-strict-optional"
             ),
             pip_cmd="{pip} install types-PyYAML",
             expected_mypy_success=True,
@@ -482,8 +482,8 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy}",
             pyright_cmd="{pyright}",
             pip_cmd=(
-                "{pip} install attrs types-six types-setuptools types-docutils "
-                "types-PyYAML types-protobuf"
+                "{pip} install attrs types-six types-setuptools types-docutils types-PyYAML"
+                " types-protobuf"
             ),
             expected_mypy_success=True,
         ),
@@ -515,8 +515,8 @@ def get_projects() -> list[Project]:
             location="https://github.com/internetarchive/openlibrary",
             mypy_cmd="{mypy} openlibrary",
             pip_cmd=(
-                "{pip} install types-PyYAML types-python-dateutil types-requests "
-                "types-simplejson types-Deprecated"
+                "{pip} install types-PyYAML types-python-dateutil types-requests types-simplejson"
+                " types-Deprecated"
             ),
             expected_mypy_success=True,
         ),
@@ -599,9 +599,8 @@ def get_projects() -> list[Project]:
             location="https://github.com/home-assistant/core",
             mypy_cmd="{mypy} homeassistant",
             pip_cmd=(
-                "{pip} install attrs pydantic "
-                "types-setuptools types-atomicwrites types-certifi types-croniter "
-                "types-PyYAML types-requests types-python-slugify types-backports"
+                "{pip} install attrs pydantic types-setuptools types-atomicwrites types-certifi"
+                " types-croniter types-PyYAML types-requests types-python-slugify types-backports"
             ),
             mypy_cost=70,
         ),
@@ -609,15 +608,17 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/ibis-project/ibis",
             mypy_cmd="{mypy} --ignore-missing-imports ibis",
-            pip_cmd="{pip} install types-setuptools types-requests "
-            "types-python-dateutil types-pytz SQLAlchemy",
+            pip_cmd=(
+                "{pip} install types-setuptools types-requests types-python-dateutil types-pytz"
+                " SQLAlchemy"
+            ),
         ),
         Project(
             location="https://github.com/streamlit/streamlit",
             mypy_cmd="{mypy} --config-file=lib/mypy.ini lib scripts",
             pip_cmd=(
-                "{pip} install attrs tornado packaging types-toml types-python-dateutil "
-                "types-setuptools types-protobuf types-pytz types-requests types-cffi click pytest"
+                "{pip} install attrs tornado packaging types-toml types-python-dateutil"
+                " types-setuptools types-protobuf types-pytz types-requests types-cffi click pytest"
             ),
         ),
         Project(
@@ -645,21 +646,25 @@ def get_projects() -> list[Project]:
             location="https://github.com/urllib3/urllib3",
             mypy_cmd="{mypy} . --exclude setup.py",
             pip_cmd=(
-                "{pip} install idna>=2.0.0 cryptography>=1.3.4 tornado>=6.1 pytest "
-                "trustme==0.9.0 types-backports types-requests"
+                "{pip} install idna>=2.0.0 cryptography>=1.3.4 tornado>=6.1 pytest trustme==0.9.0"
+                " types-backports types-requests"
             ),
         ),
         Project(
             location="https://github.com/common-workflow-language/schema_salad",
             mypy_cmd="MYPYPATH=$MYPYPATH:mypy-stubs {mypy} schema_salad",
-            pip_cmd="{pip} install types-pkg_resources types-requests "
-            "types-dataclasses types-setuptools black pytest ruamel.yaml",
+            pip_cmd=(
+                "{pip} install types-pkg_resources types-requests types-dataclasses"
+                " types-setuptools black pytest ruamel.yaml"
+            ),
         ),
         Project(
             location="https://github.com/common-workflow-language/cwltool",
             mypy_cmd="MYPYPATH=$MYPYPATH:mypy-stubs {mypy} cwltool/*.py tests/*.py",
-            pip_cmd="{pip} install types-requests types-setuptools types-psutil "
-            "types-mock cwl-utils schema-salad ruamel-yaml pytest pytest-httpserver",
+            pip_cmd=(
+                "{pip} install types-requests types-setuptools types-psutil types-mock cwl-utils"
+                " schema-salad ruamel-yaml pytest pytest-httpserver"
+            ),
             mypy_cost=20,
         ),
         Project(
@@ -706,9 +711,8 @@ def get_projects() -> list[Project]:
             location="https://github.com/canonical/cloud-init",
             mypy_cmd="{mypy} cloudinit/ tests/ tools/",
             pip_cmd=(
-                "{pip} install jinja2 pytest "
-                "types-jsonschema types-oauthlib "
-                "types-pyyaml types-requests types-setuptools"
+                "{pip} install jinja2 pytest types-jsonschema types-oauthlib types-pyyaml"
+                " types-requests types-setuptools"
             ),
             mypy_cost=20,
         ),
@@ -745,8 +749,8 @@ def get_projects() -> list[Project]:
             location="https://github.com/caronc/apprise",
             mypy_cmd="{mypy} .",
             pip_cmd=(
-                "{pip} install types-six types-mock cryptography types-requests "
-                "types-PyYAML types-Markdown pytest certifi"
+                "{pip} install types-six types-mock cryptography types-requests types-PyYAML"
+                " types-Markdown pytest certifi"
             ),
         ),
         Project(
@@ -800,9 +804,9 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} src",
             pyright_cmd="{pyright} src",
             pip_cmd=(
-                "{pip} install certifi ImageHash numpy packaging PyWinCtl PySide6-Essentials "
-                "types-D3DShot types-keyboard types-Pillow types-psutil types-PyAutoGUI "
-                "types-pyinstaller types-pywin32 types-requests types-toml"
+                "{pip} install certifi ImageHash numpy packaging PyWinCtl PySide6-Essentials"
+                " types-D3DShot types-keyboard types-Pillow types-psutil types-PyAutoGUI"
+                " types-pyinstaller types-pywin32 types-requests types-toml"
             ),
         ),
         Project(
@@ -810,8 +814,8 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} backend",
             pyright_cmd="{pyright}",
             pip_cmd=(
-                "{pip} install Flask PyJWT requests-cache types-Flask-SQLAlchemy "
-                "types-httplib2 types-requests"
+                "{pip} install Flask PyJWT requests-cache types-Flask-SQLAlchemy types-httplib2"
+                " types-requests"
             ),
             mypy_cost=30,
         ),

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -4,6 +4,16 @@ import sys
 
 from mypy_primer.model import Project
 
+# projects to re-enable:
+# - https://github.com/edgedb/edgedb
+# - https://github.com/twisted/twisted (needs mypy-zope plugin)
+
+# repos with plugins
+# - https://github.com/dry-python/returns
+# - https://github.com/strawberry-graphql/strawberry
+# - https://github.com/r-spacex/submanager
+# - https://github.com/NeilGirdhar/efax
+
 
 def get_projects() -> list[Project]:
     projects = [
@@ -391,20 +401,6 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} porcupine more_plugins",
             expected_mypy_success=True,
         ),
-        # Project(
-        #     location="https://github.com/edgedb/edgedb",
-        #     mypy_cmd="{mypy} edb",
-        #     # weeeee, extract the deps by noping out setuptools.setup and reading them
-        #     # from the setup.py
-        #     pip_cmd=(
-        #         "{pip} install "
-        #         '$(python3 -c "import setuptools; setuptools.setup=dict; '
-        #         "from edb import buildmeta; buildmeta.get_version_from_scm = lambda *a: 1; "
-        #         "import setup; "
-        #         "print(' '.join(setup.TEST_DEPS+setup.DOCS_DEPS+setup.RUNTIME_DEPS))\")"
-        #     ),
-        #     expected_mypy_success=True,
-        # ),
         Project(
             location="https://github.com/dropbox/mypy-protobuf",
             mypy_cmd="{mypy} mypy_protobuf/",
@@ -412,7 +408,6 @@ def get_projects() -> list[Project]:
             pip_cmd="{pip} install types-protobuf",
             expected_mypy_success=True,
         ),
-        # https://github.com/spack/spack/blob/develop/lib/spack/spack/cmd/style.py
         Project(
             location="https://github.com/spack/spack",
             mypy_cmd="{mypy} -p spack -p llnl",
@@ -545,39 +540,25 @@ def get_projects() -> list[Project]:
             pip_cmd="{pip} install aiohttp watchfiles types-pygments",
             expected_mypy_success=True,
         ),
-        *(
-            [
-                Project(
-                    location="https://github.com/sco1/pylox",
-                    mypy_cmd="{mypy} .",
-                    pip_cmd="{pip} install attrs",
-                    expected_mypy_success=True,
-                ),
-                Project(
-                    location="https://github.com/ppb/ppb-vector",
-                    mypy_cmd="{mypy} ppb_vector tests",
-                    pip_cmd="{pip} install hypothesis",
-                    expected_mypy_success=True,
-                ),
-            ]
-            if sys.version_info >= (3, 10)
-            else []
+        Project(
+            location="https://github.com/sco1/pylox",
+            mypy_cmd="{mypy} .",
+            pip_cmd="{pip} install attrs",
+            expected_mypy_success=True,
+            min_python_version=(3, 10),
         ),
-        # ==============================
-        # Failures expected...
-        # ==============================
+        Project(
+            location="https://github.com/ppb/ppb-vector",
+            mypy_cmd="{mypy} ppb_vector tests",
+            pip_cmd="{pip} install hypothesis",
+            expected_mypy_success=True,
+            min_python_version=(3, 10),
+        ),
         Project(
             location="https://github.com/pyppeteer/pyppeteer",
             mypy_cmd="{mypy} pyppeteer --config-file tox.ini",
             pip_cmd="{pip} install .",
         ),
-        # TODO: needs mypy-zope plugin
-        # Project(
-        #     location="https://github.com/twisted/twisted",
-        #     mypy_cmd="{mypy} src",
-        # ),
-        # Other repos with plugins:
-        # dry-python/returns, strawberry-graphql/strawberry, r-spacex/submanager, NeilGirdhar/efax
         Project(location="https://github.com/pypa/pip", mypy_cmd="{mypy} src"),
         Project(location="https://github.com/pytorch/vision", mypy_cmd="{mypy}"),
         Project(

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -35,9 +35,9 @@ def update_projects(projects: list[Project], check: bool = False) -> None:
 
     if check:
         code_proc = subprocess.run(
-            ["black", "-c", "\n".join(result)], capture_output=True, text=True
+            ["black", "-"], input="\n".join(result), capture_output=True, text=True
         )
-        code_proc.check_returncode
+        code_proc.check_returncode()
         code = code_proc.stdout
 
         with open(__file__) as f:

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -28,8 +28,8 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/hauntsaninja/pyp",
             mypy_cmd="{mypy} --strict -m pyp",
-            expected_mypy_success=True,
             pyright_cmd="{pyright}",
+            expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/pytest-dev/pytest",
@@ -194,8 +194,8 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/jab/bidict",
             mypy_cmd="{mypy} bidict",
-            expected_mypy_success=True,
             pyright_cmd="{pyright}",
+            expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/jaraco/zipp",
@@ -472,7 +472,7 @@ def get_projects() -> list[Project]:
             expected_mypy_success=True,
         ),
         Project(
-            "https://github.com/rpdelaney/downforeveryone",
+            location="https://github.com/rpdelaney/downforeveryone",
             mypy_cmd="{mypy} .",
             pip_cmd="{pip} install types-requests types-requests",
             expected_mypy_success=True,
@@ -571,15 +571,6 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} pyppeteer --config-file tox.ini",
             pip_cmd="{pip} install .",
         ),
-        Project(
-            location="https://github.com/pypa/pip",
-            mypy_cmd="{mypy} src",
-        ),
-        Project(
-            # relies on setup.py to create a version.py file
-            location="https://github.com/pytorch/vision",
-            mypy_cmd="{mypy}",
-        ),
         # TODO: needs mypy-zope plugin
         # Project(
         #     location="https://github.com/twisted/twisted",
@@ -587,6 +578,8 @@ def get_projects() -> list[Project]:
         # ),
         # Other repos with plugins:
         # dry-python/returns, strawberry-graphql/strawberry, r-spacex/submanager, NeilGirdhar/efax
+        Project(location="https://github.com/pypa/pip", mypy_cmd="{mypy} src"),
+        Project(location="https://github.com/pytorch/vision", mypy_cmd="{mypy}"),
         Project(
             location="https://github.com/tornadoweb/tornado",
             mypy_cmd="{mypy} tornado",
@@ -612,10 +605,7 @@ def get_projects() -> list[Project]:
             ),
             mypy_cost=70,
         ),
-        Project(
-            location="https://github.com/kornia/kornia",
-            mypy_cmd="{mypy} kornia",
-        ),
+        Project(location="https://github.com/kornia/kornia", mypy_cmd="{mypy} kornia"),
         Project(
             location="https://github.com/ibis-project/ibis",
             mypy_cmd="{mypy} --ignore-missing-imports ibis",
@@ -704,10 +694,7 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy}",
             pip_cmd="{pip} install pytest pproxy",
         ),
-        Project(
-            location="https://gitlab.com/dkg/python-sop",
-            mypy_cmd="{mypy} --strict sop",
-        ),
+        Project(location="https://gitlab.com/dkg/python-sop", mypy_cmd="{mypy} --strict sop"),
         Project(
             location="https://github.com/Rapptz/discord.py",
             mypy_cmd="{mypy} discord",
@@ -743,19 +730,19 @@ def get_projects() -> list[Project]:
             mypy_cost=30,
         ),
         Project(
-            "https://github.com/canonical/operator",
+            location="https://github.com/canonical/operator",
             mypy_cmd="{mypy} ops",
             pyright_cmd="{pyright}",
             pip_cmd="{pip} install types-PyYAML",
         ),
         Project(
-            "https://github.com/astropenguin/xarray-dataclasses",
+            location="https://github.com/astropenguin/xarray-dataclasses",
             mypy_cmd="{mypy} xarray_dataclasses",
             pyright_cmd="{pyright}",
             pip_cmd="{pip} install numpy xarray",
         ),
         Project(
-            "https://github.com/caronc/apprise",
+            location="https://github.com/caronc/apprise",
             mypy_cmd="{mypy} .",
             pip_cmd=(
                 "{pip} install types-six types-mock cryptography types-requests "
@@ -763,18 +750,18 @@ def get_projects() -> list[Project]:
             ),
         ),
         Project(
-            "https://github.com/daveleroy/sublime_debugger",
+            location="https://github.com/daveleroy/sublime_debugger",
             mypy_cmd="{mypy} modules --namespace-packages",
             pip_cmd="{pip} install certifi",
         ),
         Project(
-            "https://github.com/Finistere/antidote",
+            location="https://github.com/Finistere/antidote",
             mypy_cmd="{mypy} .",
             pyright_cmd="{pyright}",
             pip_cmd="{pip} install pytest",
         ),
         Project(
-            "https://github.com/cognitedata/Expression",
+            location="https://github.com/cognitedata/Expression",
             mypy_cmd="{mypy} .",
             pyright_cmd="{pyright}",
             pip_cmd="{pip} install pytest",
@@ -792,9 +779,9 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/pandas-dev/pandas-stubs",
             mypy_cmd="{mypy} pandas-stubs tests",
-            mypy_cost=20,
             pyright_cmd="{pyright}",
             expected_pyright_success=True,
+            mypy_cost=20,
         ),
         Project(
             location="https://github.com/enthought/comtypes",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [tool.black]
 line-length = 100
+# Necessary for string wrapping. Undo in 2024.
+preview = true
 
 [tool.isort]
 profile = "black"

--- a/test.sh
+++ b/test.sh
@@ -4,5 +4,5 @@ isort --diff --check --quiet .
 black --diff --check --quiet .
 flake8 --max-line-length=100 --ignore=E203,W503 $(git ls-files | grep "py$")
 mypy -p mypy_primer --strict --python-version 3.9
-# check we have unique projects
+# check we have unique projects and the list is formatted correctly
 python -c 'from mypy_primer.projects import get_projects, update_projects; update_projects(get_projects(), check=True)'

--- a/test.sh
+++ b/test.sh
@@ -5,4 +5,4 @@ black --diff --check --quiet .
 flake8 --max-line-length=100 --ignore=E203,W503 $(git ls-files | grep "py$")
 mypy -p mypy_primer --strict --python-version 3.9
 # check we have unique projects
-python -c 'from mypy_primer.projects import get_projects; get_projects()'
+python -c 'from mypy_primer.projects import get_projects, update_projects; update_projects(get_projects(), check=True)'


### PR DESCRIPTION
~~There's still a couple of things that are in the way (specifically comments and 1 specific version-specific project). Not sure how to handle that. Also `black` doesn't split string lines which means annoying flake8 :(~~ fixed.

Once the above is fixed, this means the project list can be modified at runtime e.g. to update dependencies or to cache some information (like runtime cost).