### PR TITLE
Install babel when checking apprise and Sphinx

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -72,7 +72,7 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/sphinx-doc/sphinx",
             mypy_cmd="{mypy} sphinx",
-            pip_cmd="{pip} install docutils-stubs types-requests packaging",
+            pip_cmd="{pip} install babel docutils-stubs types-requests packaging",
             expected_mypy_success=True,
         ),
         Project(
@@ -759,7 +759,7 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} .",
             pip_cmd=(
                 "{pip} install types-six types-mock cryptography types-requests "
-                "types-PyYAML types-Markdown pytest certifi"
+                "types-PyYAML types-Markdown pytest certifi babel"
             ),
         ),
         Project(


### PR DESCRIPTION
Babel is py.typed these days, and both projects list it as a dependency:

- https://github.com/caronc/apprise/blob/768b38434b99a32b178af497723ef80146e71228/dev-requirements.txt#L7
- https://github.com/sphinx-doc/sphinx/blob/b0fe7301460cac99755d12a68194b57f0939b13f/pyproject.toml#L67