### PR TITLE
Add three mypy-checked projects from CPython

### DIFF
--- a/mypy_primer/git_utils.py
+++ b/mypy_primer/git_utils.py
@@ -12,8 +12,8 @@ RevisionLike = Union[str, None, Callable[[Path], Awaitable[str]]]
 
 
 async def clone(repo_url: str, repo_dir: Path, cwd: Path, shallow: bool = False) -> None:
-    if os.path.exists(repo_url):
-        repo_url = os.path.abspath(repo_url)
+    if os.path.exists(repo_dir):
+        repo_url = os.path.abspath(repo_dir)
     cmd = ["git", "clone", "--recurse-submodules", repo_url, str(repo_dir)]
     if shallow:
         cmd += ["--depth", "1"]

--- a/mypy_primer/git_utils.py
+++ b/mypy_primer/git_utils.py
@@ -11,10 +11,11 @@ from mypy_primer.utils import run
 RevisionLike = Union[str, None, Callable[[Path], Awaitable[str]]]
 
 
-async def clone(repo_url: str, repo_dir: Path, cwd: Path, shallow: bool = False) -> None:
-    if os.path.exists(repo_url):
-        repo_url = os.path.abspath(repo_url)
-    cmd = ["git", "clone", "--recurse-submodules", repo_url, str(repo_dir)]
+# repo_source could be a URL *or* a local path
+async def clone(repo_source: str, *, repo_dir: Path, cwd: Path, shallow: bool = False) -> None:
+    if os.path.exists(repo_source):
+        repo_source = os.path.abspath(repo_source)
+    cmd = ["git", "clone", "--recurse-submodules", repo_source, str(repo_dir)]
     if shallow:
         cmd += ["--depth", "1"]
     await run(cmd, cwd=cwd)
@@ -56,7 +57,7 @@ async def ensure_repo_at_revision(
     if repo_dir.is_dir():
         await refresh(repo_dir)
     else:
-        await clone(repo_url, repo_dir, cwd, shallow=revision_like is None)
+        await clone(repo_url, repo_dir=repo_dir, cwd=cwd, shallow=revision_like is None)
     assert repo_dir.is_dir(), f"{repo_dir} is not a directory"
 
     if revision_like is None:

--- a/mypy_primer/git_utils.py
+++ b/mypy_primer/git_utils.py
@@ -48,7 +48,10 @@ async def get_revision_for_revision_or_date(revision: str, repo_dir: Path) -> st
 async def ensure_repo_at_revision(
     repo_url: str, cwd: Path, revision_like: RevisionLike, *, name_override: str | None = None
 ) -> Path:
-    repo_dir = cwd / Path(name_override or repo_url).name
+    if name_override:
+        repo_dir = cwd / name_override
+    else:
+        repo_dir = cwd / Path(repo_url).name
     if repo_dir.is_dir():
         await refresh(repo_dir)
     else:

--- a/mypy_primer/git_utils.py
+++ b/mypy_primer/git_utils.py
@@ -11,10 +11,10 @@ from mypy_primer.utils import run
 RevisionLike = Union[str, None, Callable[[Path], Awaitable[str]]]
 
 
-async def clone(repo_url: str, cwd: Path, shallow: bool = False) -> None:
+async def clone(repo_url: str, repo_dir: Path, cwd: Path, shallow: bool = False) -> None:
     if os.path.exists(repo_url):
         repo_url = os.path.abspath(repo_url)
-    cmd = ["git", "clone", "--recurse-submodules", repo_url]
+    cmd = ["git", "clone", "--recurse-submodules", repo_url, str(repo_dir)]
     if shallow:
         cmd += ["--depth", "1"]
     await run(cmd, cwd=cwd)
@@ -46,12 +46,14 @@ async def get_revision_for_revision_or_date(revision: str, repo_dir: Path) -> st
         return revision
 
 
-async def ensure_repo_at_revision(repo_url: str, cwd: Path, revision_like: RevisionLike) -> Path:
-    repo_dir = cwd / Path(repo_url).name
+async def ensure_repo_at_revision(
+    repo_url: str, cwd: Path, revision_like: RevisionLike, *, name_override: str | None = None
+) -> Path:
+    repo_dir = cwd / Path(name_override or repo_url).name
     if repo_dir.is_dir():
         await refresh(repo_dir)
     else:
-        await clone(repo_url, cwd, shallow=revision_like is None)
+        await clone(repo_url, repo_dir, cwd, shallow=revision_like is None)
     assert repo_dir.is_dir(), f"{repo_dir} is not a directory"
 
     if revision_like is None:

--- a/mypy_primer/git_utils.py
+++ b/mypy_primer/git_utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import subprocess
 from datetime import date
 from pathlib import Path
@@ -12,8 +11,8 @@ RevisionLike = Union[str, None, Callable[[Path], Awaitable[str]]]
 
 
 async def clone(repo_url: str, repo_dir: Path, cwd: Path, shallow: bool = False) -> None:
-    if os.path.exists(repo_dir):
-        repo_url = os.path.abspath(repo_dir)
+    if repo_dir.exists():
+        repo_dir = repo_dir.absolute()
     cmd = ["git", "clone", "--recurse-submodules", repo_url, str(repo_dir)]
     if shallow:
         cmd += ["--depth", "1"]

--- a/mypy_primer/git_utils.py
+++ b/mypy_primer/git_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from datetime import date
 from pathlib import Path
@@ -11,8 +12,8 @@ RevisionLike = Union[str, None, Callable[[Path], Awaitable[str]]]
 
 
 async def clone(repo_url: str, repo_dir: Path, cwd: Path, shallow: bool = False) -> None:
-    if repo_dir.exists():
-        repo_dir = repo_dir.absolute()
+    if os.path.exists(repo_url):
+        repo_url = os.path.abspath(repo_url)
     cmd = ["git", "clone", "--recurse-submodules", repo_url, str(repo_dir)]
     if shallow:
         cmd += ["--depth", "1"]

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -94,7 +94,10 @@ class Project:
         else:
             # usually projects are something clonable
             repo_dir = await ensure_repo_at_revision(
-                self.location, ctx.get().projects_dir, self.revision
+                self.location,
+                ctx.get().projects_dir,
+                self.revision,
+                name_override=self.name_override,
             )
         assert repo_dir == ctx.get().projects_dir / self.name
         if self.pip_cmd:

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -56,6 +56,8 @@ class Project:
             result += f", revision={self.revision!r}"
         if self.min_python_version:
             result += f", min_python_version={self.min_python_version!r}"
+        if self.name_override:
+            result += f", name_override={self.name_override!r}"
         result += ")"
         return result
 

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -62,7 +62,7 @@ class Project:
     @property
     def name(self) -> str:
         if self.name_override is not None:
-            return self._name_override
+            return self.name_override
         return Path(self.location).name
 
     @property

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -37,6 +37,8 @@ class Project:
     pyright_cmd: str | None = None
     expected_pyright_success: bool = False
 
+    name_override: str | None = None
+
     # custom __repr__ that omits defaults.
     def __repr__(self) -> str:
         result = f"Project(location={self.location!r}, mypy_cmd={self.mypy_cmd!r}"
@@ -59,6 +61,8 @@ class Project:
 
     @property
     def name(self) -> str:
+        if self.name_override is not None:
+            return self._name_override
         return Path(self.location).name
 
     @property

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -862,18 +862,18 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/clinic/mypy.ini",
-            name_override="https://github.com/python/cpython (Argument Clinic)",
+            name_override="CPython (Argument Clinic)",
         ),
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/cases_generator/mypy.ini",
-            name_override="https://github.com/python/cpython (cases_generator)",
+            name_override="CPython (cases_generator)",
         ),
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/peg_generator/mypy.ini",
             pip_cmd="{pip} install types-setuptools types-psutil",
-            name_override="https://github.com/python/cpython (peg_generator)",
+            name_override="CPython (peg_generator)",
         ),
     ]
     assert len(projects) == len({p.name for p in projects})

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -859,6 +859,19 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             pip_cmd="{pip} install koda",
         ),
+        Project(
+            location="https://github.com/python/cpython",
+            mypy_cmd="{mypy} --config-file Tools/clinic/mypy.ini",
+        ),
+        Project(
+            location="https://github.com/python/cpython",
+            mypy_cmd="{mypy} --config-file Tools/cases_generator/mypy.ini",
+        ),
+        Project(
+            location="https://github.com/python/cpython",
+            mypy_cmd="{mypy} --config-file Tools/peg_generator/mypy.ini",
+            pip_cmd="{pip} install types-setuptools types-psutil",
+        ),
     ]
     assert len(projects) == len({p.name for p in projects})
     return projects

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -862,15 +862,18 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/clinic/mypy.ini",
+            name_override="cpython-Argument_Clinic",
         ),
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/cases_generator/mypy.ini",
+            name_override="cpython-cases_generator",
         ),
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/peg_generator/mypy.ini",
             pip_cmd="{pip} install types-setuptools types-psutil",
+            name_override="cpython-peg_generator",
         ),
     ]
     assert len(projects) == len({p.name for p in projects})


### PR DESCRIPTION
Argument Clinic, the cases generator, and the peg generator are now all checked with mypy in CI. All have very strict settings enabled in their mypy configs (including the new `possibly-undefined` error code for the cases generator). The cases generator and Argument Clinic also make heavy use of pattern-matching; and the peg generator makes some use of relatively obscure parts of `setuptools` (which is useful for typeshed).