### PR TITLE
Fix porcupine

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -440,7 +440,7 @@ def get_projects() -> list[Project]:
         ),
         Project(
             location="https://github.com/Akuli/porcupine",
-            mypy_cmd="{mypy} porcupine more_plugins",
+            mypy_cmd="{mypy} --config-file= porcupine",
             expected_mypy_success=True,
         ),
         Project(


### PR DESCRIPTION
In https://github.com/python/typeshed/pull/10689 I noticed that I didn't get any primer output for a bad tkinter change. Porcupine is the biggest tkinter project in mypy_primer, and it turns out to be broken:
- porcupine's `mypy.ini` tells mypy to use pydantic's mypy plugin because a dependency uses pydantic v1 (might change soon). There's no good way to install pydantic into the venv where mypy is installed, so let's just ignore the config file to get reasonable diffs.
- the `more_plugins` directory no longer exists, and specifying that caused mypy to fail.

Command used to test this locally: `python3 -m mypy_primer --old 1.1.1 --new 1.1.1 --base-dir ./base-dir/ --debug --custom-typeshed-repo ~/typeshed --old-typeshed main --new-typeshed  tkinter-thingy -k porcupine -o diff`
