### PR TITLE
Once again, add 3 mypy-checked projects from CPython

### DIFF
--- a/mypy_primer/git_utils.py
+++ b/mypy_primer/git_utils.py
@@ -11,10 +11,11 @@ from mypy_primer.utils import run
 RevisionLike = Union[str, None, Callable[[Path], Awaitable[str]]]
 
 
-async def clone(repo_url: str, cwd: Path, shallow: bool = False) -> None:
-    if os.path.exists(repo_url):
-        repo_url = os.path.abspath(repo_url)
-    cmd = ["git", "clone", "--recurse-submodules", repo_url]
+# repo_source could be a URL *or* a local path
+async def clone(repo_source: str, *, repo_dir: Path, cwd: Path, shallow: bool = False) -> None:
+    if os.path.exists(repo_source):
+        repo_source = os.path.abspath(repo_source)
+    cmd = ["git", "clone", "--recurse-submodules", repo_source, str(repo_dir)]
     if shallow:
         cmd += ["--depth", "1"]
     await run(cmd, cwd=cwd)
@@ -46,12 +47,17 @@ async def get_revision_for_revision_or_date(revision: str, repo_dir: Path) -> st
         return revision
 
 
-async def ensure_repo_at_revision(repo_url: str, cwd: Path, revision_like: RevisionLike) -> Path:
-    repo_dir = cwd / Path(repo_url).name
+async def ensure_repo_at_revision(
+    repo_url: str, cwd: Path, revision_like: RevisionLike, *, name_override: str | None = None
+) -> Path:
+    if name_override:
+        repo_dir = cwd / name_override
+    else:
+        repo_dir = cwd / Path(repo_url).name
     if repo_dir.is_dir():
         await refresh(repo_dir)
     else:
-        await clone(repo_url, cwd, shallow=revision_like is None)
+        await clone(repo_url, repo_dir=repo_dir, cwd=cwd, shallow=revision_like is None)
     assert repo_dir.is_dir(), f"{repo_dir} is not a directory"
 
     if revision_like is None:

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -37,6 +37,8 @@ class Project:
     pyright_cmd: str | None = None
     expected_pyright_success: bool = False
 
+    name_override: str | None = None
+
     # custom __repr__ that omits defaults.
     def __repr__(self) -> str:
         result = f"Project(location={self.location!r}, mypy_cmd={self.mypy_cmd!r}"
@@ -54,11 +56,15 @@ class Project:
             result += f", revision={self.revision!r}"
         if self.min_python_version:
             result += f", min_python_version={self.min_python_version!r}"
+        if self.name_override:
+            result += f", name_override={self.name_override!r}"
         result += ")"
         return result
 
     @property
     def name(self) -> str:
+        if self.name_override is not None:
+            return self.name_override
         return Path(self.location).name
 
     @property
@@ -88,7 +94,10 @@ class Project:
         else:
             # usually projects are something clonable
             repo_dir = await ensure_repo_at_revision(
-                self.location, ctx.get().projects_dir, self.revision
+                self.location,
+                ctx.get().projects_dir,
+                self.revision,
+                name_override=self.name_override,
             )
         assert repo_dir == ctx.get().projects_dir / self.name
         if self.pip_cmd:

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -115,7 +115,7 @@ class Project:
                     print(e.output)
                 if e.stderr:
                     print(e.stderr)
-                raise RuntimeError(f"pip install failed for {self.location}") from e
+                raise RuntimeError(f"pip install failed for {self.name}") from e
 
     def get_mypy_cmd(self, mypy: str | Path, additional_flags: Sequence[str] = ()) -> str:
         mypy_cmd = self.mypy_cmd

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -859,6 +859,22 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             pip_cmd="{pip} install koda",
         ),
+        Project(
+            location="https://github.com/python/cpython",
+            mypy_cmd="{mypy} --config-file Tools/clinic/mypy.ini",
+            name_override="CPython (Argument Clinic)",
+        ),
+        Project(
+            location="https://github.com/python/cpython",
+            mypy_cmd="{mypy} --config-file Tools/cases_generator/mypy.ini",
+            name_override="CPython (cases_generator)",
+        ),
+        Project(
+            location="https://github.com/python/cpython",
+            mypy_cmd="{mypy} --config-file Tools/peg_generator/mypy.ini",
+            pip_cmd="{pip} install types-setuptools types-psutil",
+            name_override="CPython (peg_generator)",
+        ),
     ]
     assert len(projects) == len({p.name for p in projects})
     return projects


### PR DESCRIPTION
This is a redo of #97, which was reverted because it seemed to be causing CI in typeshed and mypy to hang. I'm still not sure exactly what was causing primer to hang in CI, but I can't reproduce it locally. I also can't reproduce it in CI anymore: I tested out this patch using my typeshed fork here, and it seems to be working fine:

- https://github.com/AlexWaygood/typeshed/pull/20

(Ignore all the failing CI on ^that demo PR -- I cancelled most of the non-primer jobs as there didn't seem to be any point wasting the CI minutes when I was only interested in mypy_primer.)