### PR TITLE
Include annotation-tests in hydra-zen

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -827,7 +827,7 @@ def get_projects() -> list[Project]:
         ),
         Project(
             location="https://github.com/mit-ll-responsible-ai/hydra-zen",
-            mypy_cmd="{mypy} src  tests/annotations/mypy_checks.py",
+            mypy_cmd="{mypy} src tests/annotations/mypy_checks.py",
             pyright_cmd="{pyright} tests/annotations src",
             pip_cmd="{pip} install pydantic beartype hydra-core",
             mypy_cost=30,

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -828,7 +828,7 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/mit-ll-responsible-ai/hydra-zen",
             mypy_cmd="{mypy} src",
-            pyright_cmd="{pyright}",
+            pyright_cmd="{pyright} tests/annotations/ src/",
             pip_cmd="{pip} install pydantic beartype hydra-core",
             mypy_cost=30,
         ),

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -827,8 +827,8 @@ def get_projects() -> list[Project]:
         ),
         Project(
             location="https://github.com/mit-ll-responsible-ai/hydra-zen",
-            mypy_cmd="{mypy} src",
-            pyright_cmd="{pyright} tests/annotations/ src/",
+            mypy_cmd="{mypy} src  tests/annotations/mypy_checks.py",
+            pyright_cmd="{pyright} tests/annotations src",
             pip_cmd="{pip} install pydantic beartype hydra-core",
             mypy_cost=30,
         ),


### PR DESCRIPTION
hydra-zen uses tests/annotations/ to test pyright against a wide variety of common usage patterns, which have frequently caught regressions in new pyright releases. This PR includes adds these files to the pyright scan of hydra-zen.

See [discussion with Eric](https://github.com/microsoft/pyright/issues/6071#issuecomment-1745229771)