### PR TITLE
Add more dependencies for meson

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -574,7 +574,7 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/mesonbuild/meson",
             mypy_cmd="./run_mypy.py --mypy {mypy}",
-            pip_cmd="{pip} install types-PyYAML",
+            pip_cmd="{pip} install coverage types-chevron types-PyYAML types-tqdm",
             expected_mypy_success=True,
         ),
         Project(


### PR DESCRIPTION
Our configuration sets ignore_missing_imports so it isn't immediately apparent these would be used...