### PR TITLE
Fix windows support for `mypy_primer --coverage`

### DIFF
--- a/mypy_primer/main.py
+++ b/mypy_primer/main.py
@@ -129,7 +129,9 @@ def select_projects() -> list[Project]:
         project_iter = (replace(p, revision=ARGS.project_date) for p in project_iter)
 
     projects = [
-        p for p in project_iter if p.only_platform is None or p.only_platform == sys.platform
+        p
+        for p in project_iter
+        if p.supported_platforms is None or sys.platform in p.supported_platforms
     ]
     if projects == []:
         raise ValueError("No projects selected!")

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -39,7 +39,7 @@ class Project:
 
     name_override: str | None = None
 
-    only_platform: str | None = None
+    supported_platforms: list[str] | None = None
 
     # custom __repr__ that omits defaults.
     def __repr__(self) -> str:
@@ -60,8 +60,8 @@ class Project:
             result += f", min_python_version={self.min_python_version!r}"
         if self.name_override:
             result += f", name_override={self.name_override!r}"
-        if self.only_platform:
-            result += f", only_platform={self.only_platform!r}"
+        if self.supported_platforms:
+            result += f", supported_platforms={self.supported_platforms!r}"
         result += ")"
         return result
 

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -112,7 +112,7 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} aiohttp",
             pip_cmd="AIOHTTP_NO_EXTENSIONS=1 {pip} install -e . pytest",
             expected_mypy_success=True,
-            only_platform="linux",
+            supported_platforms=["linux", "darwin"],
         ),
         Project(
             location="https://github.com/python-attrs/attrs",
@@ -145,7 +145,7 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} boostedblob",
             pip_cmd="{pip} install aiohttp uvloop pycryptodome",
             expected_mypy_success=True,
-            only_platform="linux",
+            supported_platforms=["linux", "darwin"],
         ),
         Project(
             location="https://github.com/quora/asynq",
@@ -229,7 +229,7 @@ def get_projects() -> list[Project]:
                 " types-pytz types-PyYAML types-requests"
             ),
             expected_mypy_success=True,
-            only_platform="linux",
+            supported_platforms=["linux", "darwin"],
         ),
         Project(
             location="https://github.com/PrefectHQ/prefect",
@@ -341,7 +341,7 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} src/schemathesis",
             pip_cmd="{pip} install attrs types-requests types-PyYAML",
             expected_mypy_success=True,
-            only_platform="linux",
+            supported_platforms=["linux", "darwin"],
         ),
         Project(
             location="https://github.com/graphql-python/graphql-core",
@@ -592,7 +592,7 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} .",
             pip_cmd="{pip} install types-Pillow types-cachetools types-requests attrs",
             expected_mypy_success=True,
-            only_platform="linux",
+            supported_platforms=["linux", "darwin"],
         ),
         Project(
             location="https://github.com/sco1/pylox",
@@ -896,5 +896,7 @@ def get_projects() -> list[Project]:
     ]
     assert len(projects) == len({p.name for p in projects})
     for p in projects:
-        assert p.only_platform is None or p.only_platform == "linux"
+        assert p.supported_platforms is None or all(
+            p in ("linux", "darwin") for p in p.supported_platforms
+        )
     return projects


### PR DESCRIPTION
This makes `mypy_primer --coverage` run without errors... though the output is wrong:

```
Checking 131 projects...
Containing 0 files...
Totalling to 0 lines...
```

Good enough.