### PR TITLE
Add support for type checking with mypy plugins

### DIFF
--- a/mypy_primer/globals.py
+++ b/mypy_primer/globals.py
@@ -52,6 +52,14 @@ class _Args:
 
     projects_dir: Path = field(init=False)
 
+    @property
+    def venv_dir(self) -> Path:
+        return self.base_dir / "python"
+
+    @property
+    def pip_exe(self) -> Path:
+        return self.venv_dir / mypy_primer.utils.BIN_DIR / "pip"
+
 
 ctx = contextvars.ContextVar[_Args]("args")
 

--- a/mypy_primer/globals.py
+++ b/mypy_primer/globals.py
@@ -52,14 +52,6 @@ class _Args:
 
     projects_dir: Path = field(init=False)
 
-    @property
-    def venv_dir(self) -> Path:
-        return self.base_dir / "python"
-
-    @property
-    def pip_exe(self) -> Path:
-        return self.venv_dir / mypy_primer.utils.BIN_DIR / "pip"
-
 
 ctx = contextvars.ContextVar[_Args]("args")
 

--- a/mypy_primer/main.py
+++ b/mypy_primer/main.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import sys
 import traceback
+import venv
 from dataclasses import replace
 from pathlib import Path
 from typing import Awaitable, Iterator, TypeVar
@@ -336,6 +337,8 @@ async def primer() -> int:
     projects = select_projects()
     ARGS = ctx.get()
 
+    # Create a python executable with pip that all projects can share
+    venv.create(ARGS.venv_dir, with_pip=True, clear=True)
     if ARGS.type_checker == "mypy":
         new_type_checker, old_type_checker = await setup_new_and_old_mypy(
             new_mypy_revision=ARGS.new,

--- a/mypy_primer/main.py
+++ b/mypy_primer/main.py
@@ -6,7 +6,6 @@ import re
 import shutil
 import sys
 import traceback
-import venv
 from dataclasses import replace
 from pathlib import Path
 from typing import Awaitable, Iterator, TypeVar
@@ -337,8 +336,6 @@ async def primer() -> int:
     projects = select_projects()
     ARGS = ctx.get()
 
-    # Create a python executable with pip that all projects can share
-    venv.create(ARGS.venv_dir, with_pip=True, clear=True)
     if ARGS.type_checker == "mypy":
         new_type_checker, old_type_checker = await setup_new_and_old_mypy(
             new_mypy_revision=ARGS.new,

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -229,7 +229,9 @@ class Project:
             cwd=ctx.get().projects_dir / self.name,
         )
         if ctx.get().debug:
-            debug_print(f"{Style.BLUE}{pyright.path} on {self.name} took {runtime:.2f}s{Style.RESET}")
+            debug_print(
+                f"{Style.BLUE}{pyright.path} on {self.name} took {runtime:.2f}s{Style.RESET}"
+            )
 
         output = proc.stderr + proc.stdout
         return TypeCheckResult(

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -9,7 +9,6 @@ import shutil
 import subprocess
 import sys
 import textwrap
-import venv
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -642,15 +642,12 @@ def get_projects() -> list[Project]:
         ),
         Project(
             location="https://github.com/home-assistant/core",
-            mypy_cmd=(
-                "sed -i.bak '/^plugins = pydantic.mypy$/s/^/#/' mypy.ini; {mypy} homeassistant"
-            ),
+            mypy_cmd="{mypy} homeassistant",
             pip_cmd=(
                 "{pip} install attrs pydantic types-setuptools types-atomicwrites types-certifi"
                 " types-croniter types-PyYAML types-requests types-python-slugify types-backports"
             ),
             mypy_cost=70,
-            supported_platforms=["linux", "darwin"],  # hack for sed
         ),
         Project(location="https://github.com/kornia/kornia", mypy_cmd="{mypy} kornia"),
         Project(
@@ -911,6 +908,12 @@ def get_projects() -> list[Project]:
                 "{pip} install types-pyOpenSSL types-cffi attrs outcome exceptiongroup pytest"
                 " sniffio"
             ),
+        ),
+        Project(
+            location="https://github.com/flaeppe/django-choicefield",
+            mypy_cmd="{mypy}",
+            pip_cmd="{pip} install . django-stubs pytest",
+            expected_mypy_success=True,
         ),
     ]
     assert len(projects) == len({p.name for p in projects})


### PR DESCRIPTION
~I'm not totally sure if this approach always works or if there's stuff that I'm missing, but it seems to work. I'll try to explain myself here.~

~The change utilises `pip`'s `--target`([docs](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-t)) argument to point out where to install a project's additional dependencies, passed in via `pip_cmd`. This replaces the virtual env creation for each project, since that shouldn't be necessary (I think?).~

~In addition to what's mentioned above~ we start setting the `PYTHONPATH` env variable([docs](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH)), to point out an additional search path for module files, namely the site-packages directory ~with the additional dependencies~ inside the project's virtualenv.

That should allow discovery of project dependencies while keeping the installed mypy versions independent and reusable.

- Closes #8 
- Closes #102 

<details>
  <summary>Outdated</summary>

---

All this _isn't_ included, but I was thinking that it _should_ be possible to use `pip install --target` for both mypy installations as well, instead of a virtual env. That leads to having 1 python/pip executable, 1 directory for `new_mypy`, 1 directory for `old_mypy` and then all project dependency installations. Although I'm unsure what `--python-executable=` does and if it could be affected. I'm also not sure how to handle compiled mypy.

Essentially what'll happen with the above changes is that we'll have a directory structure like e.g.

```bash
repo-dir/
├── new_mypy
│   └── bin
│       └── mypy
├── old_mypy
│   └── bin
│       └── mypy
├── projects
│   ├── A
│   └── B
└── python
    └── bin
        └── python
```

We run mypy with something corresponding to

```
PYTHONPATH="repo-dir/new_mypy:repo-dir/projects/A" repo-dir/new_mypy/bin/mypy --python-executable=repo-dir/python/bin/python ...
PYTHONPATH="repo-dir/old_mypy:repo-dir/projects/A" repo-dir/old_mypy/bin/mypy --python-executable=repo-dir/python/bin/python ...
```
</details>

---

Here's some example debug output:

```
...
/tmp/mypy_primer/projects/_django-choicefield_venv/bin/pip install . django-stubs pytest         in /tmp/mypy_primer/projects/django-choicefield
PYTHONPATH=/tmp/mypy_primer/new_mypy/venv/lib/python3.12/site-packages:/tmp/mypy_primer/projects/_django-choicefield_venv/lib/python3.12/site-packages
/tmp/mypy_primer/new_mypy/venv/bin/mypy --python-executable=/tmp/mypy_primer/projects/_django-choicefield_venv/bin/python --warn-unused-ignores --warn-redundant-casts --no-incremental --cache-dir=/dev/null --show-traceback --soft-error-limit=-1     in /tmp/mypy_primer/projects/django-choicefield
PYTHONPATH=/tmp/mypy_primer/old_mypy/venv/lib/python3.12/site-packages:/tmp/mypy_primer/projects/_django-choicefield_venv/lib/python3.12/site-packages
/tmp/mypy_primer/old_mypy/venv/bin/mypy --python-executable=/tmp/mypy_primer/projects/_django-choicefield_venv/bin/python --warn-unused-ignores --warn-redundant-casts --no-incremental --cache-dir=/dev/null --show-traceback --soft-error-limit=-1     in /tmp/mypy_primer/projects/django-choicefield
/tmp/mypy_primer/new_mypy/venv/bin/mypy on django-choicefield took 4.96s
/tmp/mypy_primer/old_mypy/venv/bin/mypy on django-choicefield took 4.98s
...
```