### PR TITLE
Fix django-stubs installation

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1221,7 +1221,7 @@ def get_projects() -> list[Project]:
             ],
             needs_mypy_plugins=True,
             expected_mypy_success=True,
-            install_cmd="{install} .",
+            install_cmd="{install} . ./ext",
         ),
     ]
     assert len(projects) == len({p.name for p in projects})


### PR DESCRIPTION
django-stubs has two packages that both need to be installed from Git. Otherwise we get this error (and mypy_primer seems to hang forever).

```
  × No solution found when resolving dependencies:
  ╰─▶ Because only django-stubs-ext<5.0.3 is available and django-stubs==5.0.3 depends on django-stubs-ext>=5.0.3, we can conclude that django-stubs==5.0.3 cannot be used.
      And because only django-stubs==5.0.3 is available and you require django-stubs, we can conclude that the requirements are unsatisfiable.
```

- https://github.com/hauntsaninja/mypy_primer/pull/124#issuecomment-2252773749