### PR TITLE
Project: use list of paths instead of `pyright_cmd`

### DIFF
--- a/mypy_primer/main.py
+++ b/mypy_primer/main.py
@@ -118,7 +118,7 @@ def select_projects() -> list[Project]:
         if not (p.min_python_version and sys.version_info < p.min_python_version)
     )
     if ARGS.type_checker == "pyright":
-        project_iter = iter(p for p in project_iter if p.pyright_cmd is not None)
+        project_iter = iter(p for p in project_iter if not p.pyright_skip)
     if ARGS.project_selector:
         project_iter = iter(
             p for p in project_iter if re.search(ARGS.project_selector, p.location, flags=re.I)

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -25,7 +25,12 @@ class Project:
     name_override: str | None = None
 
     mypy_cmd: str
-    pyright_cmd: str | None
+
+    # Whether or not to run pyright on this project
+    pyright_skip: bool = False
+
+    # A list of explicit paths that are passed to the type checker (currently only used for pyright)
+    paths: list[str] | None = None
 
     install_cmd: str | None = None
     deps: list[str] | None = None
@@ -52,8 +57,8 @@ class Project:
         result = f"Project(location={self.location!r}, mypy_cmd={self.mypy_cmd!r}"
         if self.name_override:
             result += f", name_override={self.name_override!r}"
-        if self.pyright_cmd:
-            result += f", pyright_cmd={self.pyright_cmd!r}"
+        if self.paths:
+            result += f", paths={self.paths!r}"
         if self.install_cmd:
             result += f", install_cmd={self.install_cmd!r}"
         if self.deps:
@@ -245,8 +250,9 @@ class Project:
         )
 
     def get_pyright_cmd(self, pyright: Path, additional_flags: Sequence[str] = ()) -> str:
-        pyright_cmd = self.pyright_cmd or "{pyright}"
-        assert "{pyright}" in pyright_cmd
+        paths = self.paths or []
+        pyright_cmd = "{pyright} " + " ".join(paths)
+
         if additional_flags:
             pyright_cmd += " " + " ".join(additional_flags)
         pyright_cmd = pyright_cmd.format(pyright=pyright)
@@ -337,7 +343,7 @@ for source in sources:
                 if header.startswith("# flags:"):
                     additional_flags = header[len("# flags:") :]
         return Project(
-            location=location, mypy_cmd=f"{{mypy}} {location} {additional_flags}", pyright_cmd=None
+            location=location, mypy_cmd=f"{{mypy}} {location} {additional_flags}", paths=None
         )
 
 

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -75,7 +75,7 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/python/mypy",
             mypy_cmd="{mypy} --config-file mypy_self_check.ini -p mypy -p mypyc",
-            pyright_cmd="{pyright} mypy mypyc",
+            paths=["mypy", "mypyc"],
             deps=["pytest", "types-psutil", "types-setuptools", "filelock", "tomli"],
             expected_mypy_success=True,
             cost={"mypy": 15, "pyright": 50},
@@ -83,33 +83,30 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/hauntsaninja/mypy_primer",
             mypy_cmd="{mypy} -p mypy_primer --strict",
-            pyright_cmd="{pyright}",
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/psf/black",
             mypy_cmd="{mypy} src",
-            pyright_cmd="{pyright} src",
+            paths=["src"],
             deps=["aiohttp", "click", "pathspec", "tomli", "platformdirs", "packaging"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/hauntsaninja/pyp",
             mypy_cmd="{mypy} --strict -m pyp",
-            pyright_cmd="{pyright}",
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/pytest-dev/pytest",
             mypy_cmd="{mypy} src testing",
-            pyright_cmd="{pyright}",
             deps=["attrs", "pluggy", "py", "types-setuptools"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/pandas-dev/pandas",
             mypy_cmd="{mypy} pandas",
-            pyright_cmd="{pyright} pandas",
+            paths=["pandas"],
             deps=[
                 "numpy",
                 "types-python-dateutil",
@@ -124,14 +121,14 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/pycqa/pylint",
             mypy_cmd="{mypy} pylint/checkers --ignore-missing-imports",
-            pyright_cmd="{pyright} pylint/checkers",
+            paths=["pylint/checkers"],
             deps=["types-toml"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/aio-libs/aiohttp",
             mypy_cmd="{mypy} aiohttp",
-            pyright_cmd="{pyright} aiohttp",
+            paths=["aiohttp"],
             deps=["pytest"],
             install_cmd="AIOHTTP_NO_EXTENSIONS=1 {install} -e .",
             expected_mypy_success=True,
@@ -144,20 +141,19 @@ def get_projects() -> list[Project]:
                 " src/attr/exceptions.pyi src/attr/filters.pyi src/attr/setters.pyi"
                 " src/attr/validators.pyi tests/typing_example.py"
             ),
-            pyright_cmd="{pyright}",
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/sphinx-doc/sphinx",
             mypy_cmd="{mypy} sphinx",
-            pyright_cmd="{pyright} sphinx",
+            paths=["sphinx"],
             deps=["babel", "docutils-stubs", "types-requests", "packaging", "jinja2"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/scikit-learn/scikit-learn",
             mypy_cmd="{mypy} sklearn",
-            pyright_cmd="{pyright} sklearn",
+            paths=["sklearn"],
             deps=["numpy"],
             expected_mypy_success=True,
             cost={"mypy": 15, "pyright": 240},
@@ -165,14 +161,14 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/pypa/bandersnatch",
             mypy_cmd="{mypy} src",
-            pyright_cmd="{pyright} src",
+            paths=["src"],
             deps=["types-filelock", "types-freezegun", "types-setuptools"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/hauntsaninja/boostedblob",
             mypy_cmd="{mypy} boostedblob",
-            pyright_cmd="{pyright} boostedblob",
+            paths=["boostedblob"],
             deps=["aiohttp", "uvloop", "pycryptodome"],
             expected_mypy_success=True,
             supported_platforms=["linux", "darwin"],
@@ -180,34 +176,32 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/quora/asynq",
             mypy_cmd="{mypy} asynq",
-            pyright_cmd="{pyright} asynq",
+            paths=["asynq"],
             deps=["qcore"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/scrapy/scrapy",
             mypy_cmd="{mypy} scrapy tests",
-            pyright_cmd="{pyright}",
             deps=["attrs", "types-pyOpenSSL", "types-setuptools"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/pypa/twine",
             mypy_cmd="{mypy} twine",
-            pyright_cmd="{pyright} twine",
+            paths=["twine"],
             deps=["keyring", "types-requests", "rich"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/more-itertools/more-itertools",
             mypy_cmd="{mypy} more_itertools",
-            pyright_cmd="{pyright} more_itertools",
+            paths=["more_itertools"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/pydata/xarray",
             mypy_cmd="{mypy} --exclude conftest.py",
-            pyright_cmd="{pyright}",
             deps=["types-PyYAML", "types-python-dateutil", "types-pytz", "numpy"],
             expected_mypy_success=True,
             cost={"mypy": 25, "pyright": 170},
@@ -215,34 +209,31 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/pallets/werkzeug",
             mypy_cmd="{mypy} src/werkzeug tests",
-            pyright_cmd="{pyright}",
             deps=["types-setuptools", "pytest", "markupsafe"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/pallets/jinja",
             mypy_cmd="{mypy}",
-            pyright_cmd="{pyright}",
             deps=["markupsafe"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/mystor/git-revise",
             mypy_cmd="{mypy} gitrevise",
-            pyright_cmd="{pyright} gitrevise",
+            paths=["gitrevise"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/PyGithub/PyGithub",
             mypy_cmd="{mypy} github tests",
-            pyright_cmd="{pyright}",
             deps=["types-requests", "pyjwt"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/we-like-parsers/pegen",
             mypy_cmd="{mypy} src/pegen",
-            pyright_cmd="{pyright} src/pegen",
+            paths=["src/pegen"],
             expected_mypy_success=True,
         ),
         Project(
@@ -250,7 +241,6 @@ def get_projects() -> list[Project]:
             mypy_cmd=(
                 "{mypy} zerver zilencer zproject tools analytics corporate scripts --platform=linux"
             ),
-            pyright_cmd="{pyright}",
             deps=[
                 "types-PyYAML",
                 "types-polib",
@@ -273,14 +263,13 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/dropbox/stone",
             mypy_cmd="{mypy} stone test",
-            pyright_cmd="{pyright}",
             deps=["types-six"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/yelp/paasta",
             mypy_cmd="{mypy} paasta_tools",
-            pyright_cmd="{pyright} paasta_tools",
+            paths=["paasta_tools"],
             deps=[
                 "types-retry",
                 "types-tzlocal",
@@ -296,7 +285,7 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/PrefectHQ/prefect",
             mypy_cmd="{mypy} src/prefect --exclude conftest.py",
-            pyright_cmd="{pyright} src",
+            paths=["src"],
             deps=[
                 "types-python-dateutil",
                 "types-requests",
@@ -317,58 +306,52 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/pallets/itsdangerous",
             mypy_cmd="{mypy}",
-            pyright_cmd="{pyright}",
             deps=["pytest"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/jab/bidict",
             mypy_cmd="{mypy} bidict",
-            pyright_cmd="{pyright}",
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/jaraco/zipp",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/aaugustin/websockets",
             mypy_cmd="{mypy} --strict src",
-            pyright_cmd="{pyright}",
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/pycqa/isort",
             mypy_cmd="{mypy} --ignore-missing-imports isort",
-            pyright_cmd="{pyright} isort",
+            paths=["isort"],
             deps=["types-setuptools"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/aio-libs/aioredis",
             mypy_cmd="{mypy} aioredis --ignore-missing-imports",
-            pyright_cmd="{pyright} aioredis",
+            paths=["aioredis"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/agronholm/anyio",
             mypy_cmd="{mypy} src",
-            pyright_cmd="{pyright} src",
+            paths=["src"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/aio-libs/yarl",
             mypy_cmd="{mypy} --show-error-codes yarl tests",
-            pyright_cmd="{pyright}",
             deps=["multidict"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/freqtrade/freqtrade",
             mypy_cmd="{mypy} freqtrade scripts",
-            pyright_cmd="{pyright}",
             deps=[
                 "types-cachetools",
                 "types-requests",
@@ -385,7 +368,7 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/google/jax",
             mypy_cmd="{mypy} jax",
-            pyright_cmd="{pyright} jax",
+            paths=["jax"],
             deps=["types-requests", "numpy"],
             expected_mypy_success=True,
             cost={"mypy": 30, "pyright": 90},
@@ -393,14 +376,13 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/dulwich/dulwich",
             mypy_cmd="{mypy} dulwich",
-            pyright_cmd="{pyright} dulwich",
+            paths=["dulwich"],
             deps=["types-certifi", "types-paramiko"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/optuna/optuna",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             deps=["types-PyYAML", "types-redis", "types-setuptools", "SQLAlchemy", "numpy"],
             expected_mypy_success=True,
             cost={"mypy": 25, "pyright": 70},
@@ -408,7 +390,6 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/trailofbits/manticore",
             mypy_cmd="{mypy}",
-            pyright_cmd="{pyright}",
             deps=["types-protobuf", "types-PyYAML", "types-redis", "types-setuptools"],
             expected_mypy_success=True,
             cost={"mypy": 15, "pyright": 75},
@@ -416,21 +397,19 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/aiortc/aiortc",
             mypy_cmd="{mypy} src",
-            pyright_cmd="{pyright} src",
+            paths=["src"],
             deps=["cryptography"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/Textualize/rich",
             mypy_cmd="{mypy} -p rich --ignore-missing-imports --warn-unreachable",
-            pyright_cmd="{pyright}",
             deps=["attrs"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/dedupeio/dedupe",
             mypy_cmd="{mypy} --ignore-missing-imports dedupe",
-            pyright_cmd="{pyright}",
             deps=["numpy"],
             needs_mypy_plugins=True,
             expected_mypy_success=True,
@@ -438,7 +417,7 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/schemathesis/schemathesis",
             mypy_cmd="{mypy} src/schemathesis",
-            pyright_cmd="{pyright} src/schemathesis",
+            paths=["src/schemathesis"],
             deps=["attrs", "types-requests", "types-PyYAML", "hypothesis"],
             expected_mypy_success=True,
             supported_platforms=["linux", "darwin"],
@@ -446,112 +425,103 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/graphql-python/graphql-core",
             mypy_cmd="{mypy} src tests",
-            pyright_cmd="{pyright} src tests",
+            paths=["src", "tests"],
             expected_mypy_success=True,
             cost={"mypy": 40},
         ),
         Project(
             location="https://github.com/Legrandin/pycryptodome",
             mypy_cmd="{mypy} lib",
-            pyright_cmd="{pyright}",
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/niklasf/python-chess",
             mypy_cmd="{mypy} --strict chess",
-            pyright_cmd="{pyright} chess",
+            paths=["chess"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/pytorch/ignite",
             mypy_cmd="{mypy}",
-            pyright_cmd="{pyright}",
             expected_mypy_success=True,
             cost={"pyright": 50},
         ),
         Project(
             location="https://github.com/pypa/packaging",
             mypy_cmd="{mypy} src",
-            pyright_cmd="{pyright} src",
+            paths=["src"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/pydantic/pydantic",
             mypy_cmd="{mypy} pydantic",
-            pyright_cmd="{pyright}",
             deps=["types-toml"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/encode/starlette",
             mypy_cmd="{mypy} starlette tests",
-            pyright_cmd="{pyright}",
             deps=["types-requests", "types-PyYAML"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/aio-libs/janus",
             mypy_cmd="{mypy} janus --disallow-untyped-calls --disallow-incomplete-defs --strict",
-            pyright_cmd="{pyright}",
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/alerta/alerta",
             mypy_cmd="{mypy} alerta tests",
-            pyright_cmd="{pyright}",
             deps=["types-PyYAML", "types-setuptools", "types-requests", "types-pytz"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/nolar/kopf",
             mypy_cmd="{mypy} kopf",
-            pyright_cmd="{pyright}",
             deps=["types-setuptools", "types-PyYAML"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/davidhalter/parso",
             mypy_cmd="{mypy} parso",
-            pyright_cmd="{pyright} parso",
+            paths=["parso"],
             expected_mypy_success=True,
             cost={"pyright": 75},
         ),
         Project(
             location="https://github.com/konradhalas/dacite",
             mypy_cmd="{mypy} dacite",
-            pyright_cmd="{pyright} dacite",
+            paths=["dacite"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/ilevkivskyi/com2ann",
             mypy_cmd="{mypy} --python-version=3.8 src/com2ann.py src/test_com2ann.py",
-            pyright_cmd="{pyright} com2ann",
+            paths=["com2ann"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/srittau/python-htmlgen",
             mypy_cmd="{mypy} htmlgen test_htmlgen",
-            pyright_cmd="{pyright}",
             deps=["asserts"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/mitmproxy/mitmproxy",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/jpadilla/pyjwt",
             mypy_cmd="{mypy} jwt",
-            pyright_cmd="{pyright} jwt",
+            paths=["jwt"],
             deps=["cryptography"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/apache/spark",
             mypy_cmd="{mypy} --config python/mypy.ini python/pyspark",
-            pyright_cmd="{pyright} python/pyspark",
+            paths=["python/pyspark"],
             deps=["numpy"],
             expected_mypy_success=True,
             cost={"mypy": 20, "pyright": 110},
@@ -559,40 +529,36 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/laowantong/paroxython",
             mypy_cmd="{mypy} paroxython",
-            pyright_cmd="{pyright} paroxython",
+            paths=["paroxython"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/Akuli/porcupine",
             mypy_cmd="{mypy} --config-file= porcupine",
-            pyright_cmd="{pyright} porcupine",
+            paths=["porcupine"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/dropbox/mypy-protobuf",
             mypy_cmd="{mypy} mypy_protobuf/",
-            pyright_cmd="{pyright}",
             deps=["types-protobuf"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/spack/spack",
             mypy_cmd="{mypy} -p spack -p llnl",
-            pyright_cmd="{pyright}",
             expected_mypy_success=True,
             cost={"mypy": 20, "pyright": 100},
         ),
         Project(
             location="https://github.com/johtso/httpx-caching",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             deps=["types-freezegun", "types-mock", "httpx", "anyio", "pytest"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/python-poetry/poetry",
             mypy_cmd="{mypy}",
-            pyright_cmd="{pyright}",
             deps=["types-requests"],
             expected_mypy_success=True,
         ),
@@ -602,56 +568,51 @@ def get_projects() -> list[Project]:
                 "{mypy} --ignore-missing-imports --follow-imports=silent @typechecked-files"
                 " --no-strict-optional"
             ),
-            pyright_cmd=None,
+            pyright_skip=True,
             deps=["types-PyYAML"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/wntrblm/nox",
             mypy_cmd="{mypy} nox",
-            pyright_cmd="{pyright} nox",
+            paths=["nox"],
             deps=["jinja2", "packaging", "importlib_metadata"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/pandera-dev/pandera",
             mypy_cmd="{mypy} pandera tests",
-            pyright_cmd="{pyright}",
             deps=["types-click", "types-PyYAML", "types-setuptools", "types-requests"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://gitlab.com/cki-project/cki-lib",
             mypy_cmd="{mypy} --strict .",
-            pyright_cmd="{pyright}",
             deps=["types-PyYAML", "types-requests"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/python-jsonschema/check-jsonschema",
             mypy_cmd="{mypy} src",
-            pyright_cmd="{pyright} src",
+            paths=["src"],
             deps=["types-jsonschema", "types-requests"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/pybind/pybind11",
             mypy_cmd="{mypy} --exclude '^(tests|docs)/' .",
-            pyright_cmd="{pyright}",
             deps=["nox", "rich"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/rpdelaney/downforeveryone",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             deps=["types-requests", "types-requests", "pytest"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/DataDog/dd-trace-py",
             mypy_cmd="{mypy}",
-            pyright_cmd="{pyright}",
             deps=[
                 "attrs",
                 "types-six",
@@ -668,34 +629,32 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/systemd/mkosi",
             mypy_cmd="{mypy} mkosi",
-            pyright_cmd="{pyright}",
             deps=["cryptography"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/sympy/sympy",
             mypy_cmd="{mypy} sympy",
-            pyright_cmd="{pyright} sympy",
+            paths=["sympy"],
             expected_mypy_success=True,
             cost={"mypy": 35, "pyright": 240},
         ),
         Project(
             location="https://github.com/nion-software/nionutils",
             mypy_cmd="{mypy} --strict -p nion.utils",
-            pyright_cmd="{pyright}",
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/PyCQA/flake8-pyi",
             mypy_cmd="{mypy} pyi.py",
-            pyright_cmd="{pyright} pyi.py",
+            paths=["pyi.py"],
             deps=["types-pyflakes"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/internetarchive/openlibrary",
             mypy_cmd="{mypy} openlibrary",
-            pyright_cmd="{pyright} openlibrary",
+            paths=["openlibrary"],
             deps=[
                 "types-PyYAML",
                 "types-python-dateutil",
@@ -708,35 +667,31 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/JohannesBuchner/imagehash",
             mypy_cmd="{mypy} imagehash",
-            pyright_cmd="{pyright}",
             deps=["numpy", "types-Pillow"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/Kalmat/PyWinCtl",
             mypy_cmd="{mypy} src/pywinctl",
-            pyright_cmd="{pyright}",
             deps=["types-setuptools", "types-pywin32", "types-python-xlib"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/mesonbuild/meson",
             mypy_cmd="./run_mypy.py --mypy {mypy}",
-            pyright_cmd=None,
+            pyright_skip=True,
             deps=["types-PyYAML", "coverage", "types-chevron", "types-PyYAML", "types-tqdm"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/aio-libs/aiohttp-devtools",
             mypy_cmd="{mypy}",
-            pyright_cmd="{pyright}",
             deps=["aiohttp", "watchfiles", "types-pygments"],
             expected_mypy_success=True,
         ),
         Project(
             location="https://github.com/sco1/pylox",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             deps=["attrs", "pytest"],
             expected_mypy_success=True,
             min_python_version=(3, 10),
@@ -744,7 +699,6 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/ppb/ppb-vector",
             mypy_cmd="{mypy} ppb_vector tests",
-            pyright_cmd="{pyright}",
             deps=["hypothesis"],
             expected_mypy_success=True,
             min_python_version=(3, 10),
@@ -752,7 +706,6 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/mkdocs/mkdocs",
             mypy_cmd="{mypy} mkdocs",
-            pyright_cmd="{pyright}",
             deps=[
                 "babel",
                 "types-Markdown",
@@ -771,31 +724,27 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/pyppeteer/pyppeteer",
             mypy_cmd="{mypy} pyppeteer --config-file tox.ini",
-            pyright_cmd="{pyright}",
             install_cmd="{install} .",
         ),
         Project(
             location="https://github.com/pypa/pip",
             mypy_cmd="{mypy} src",
-            pyright_cmd="{pyright}",
             cost={"pyright": 45},
         ),
         Project(
             location="https://github.com/pytorch/vision",
             mypy_cmd="{mypy}",
-            pyright_cmd="{pyright}",
             cost={"pyright": 50},
         ),
         Project(
             location="https://github.com/tornadoweb/tornado",
             mypy_cmd="{mypy} tornado",
-            pyright_cmd="{pyright}",
             deps=["types-contextvars", "types-pycurl"],
         ),
         Project(
             location="https://github.com/scipy/scipy",
             mypy_cmd="{mypy} scipy",
-            pyright_cmd=None,
+            pyright_skip=True,
             deps=["numpy", "pytest", "hypothesis", "types-psutil"],
             needs_mypy_plugins=True,
             cost={"mypy": 25},
@@ -803,13 +752,12 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/pycqa/flake8",
             mypy_cmd="{mypy} src tests",
-            pyright_cmd="{pyright}",
             deps=["pytest"],
         ),
         Project(
             location="https://github.com/home-assistant/core",
             mypy_cmd="{mypy} homeassistant",
-            pyright_cmd="{pyright} homeassistant",
+            paths=["homeassistant"],
             deps=[
                 "attrs",
                 "pydantic",
@@ -828,12 +776,12 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/kornia/kornia",
             mypy_cmd="{mypy} kornia",
-            pyright_cmd="{pyright} kornia",
+            paths=["kornia"],
         ),
         Project(
             location="https://github.com/ibis-project/ibis",
             mypy_cmd="{mypy} --ignore-missing-imports ibis",
-            pyright_cmd="{pyright} ibis",
+            paths=["ibis"],
             deps=[
                 "types-setuptools",
                 "types-requests",
@@ -846,7 +794,6 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/streamlit/streamlit",
             mypy_cmd="{mypy} --config-file=lib/mypy.ini lib scripts",
-            pyright_cmd="{pyright}",
             deps=[
                 "attrs",
                 "tornado",
@@ -866,33 +813,29 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/dragonchain/dragonchain",
             mypy_cmd="{mypy} dragonchain --error-summary",
-            pyright_cmd="{pyright} dragonchain",
+            paths=["dragonchain"],
             deps=["types-redis", "types-requests"],
         ),
         Project(
             location="https://github.com/mikeshardmind/SinbadCogs",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             deps=["attrs", "types-pytz", "types-python-dateutil", "types-PyYAML"],
         ),
         Project(
             location="https://github.com/rotki/rotki",
             mypy_cmd="{mypy} rotkehlchen/ tools/data_faker",
-            pyright_cmd="{pyright}",
             deps=["eth-typing", "types-requests", "types-setuptools"],
             cost={"pyright": 60},
         ),
         Project(
             location="https://github.com/arviz-devs/arviz",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             deps=["pytest", "types-setuptools", "types-ujson", "numpy", "xarray"],
             cost={"pyright": 45},
         ),
         Project(
             location="https://github.com/urllib3/urllib3",
             mypy_cmd="{mypy} . --exclude setup.py",
-            pyright_cmd="{pyright}",
             deps=[
                 "idna>=2.0.0",
                 "cryptography>=1.3.4",
@@ -906,7 +849,7 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/common-workflow-language/schema_salad",
             mypy_cmd="MYPYPATH=$MYPYPATH:mypy-stubs {mypy} schema_salad",
-            pyright_cmd=None,
+            pyright_skip=True,
             install_cmd="{install} $(grep -v mypy mypy-requirements.txt)" " -r requirements.txt",
             expected_mypy_success=True,
             supported_platforms=["linux", "darwin"],
@@ -914,7 +857,7 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/common-workflow-language/cwltool",
             mypy_cmd="MYPYPATH=$MYPYPATH:mypy-stubs {mypy} cwltool tests/*.py setup.py",
-            pyright_cmd=None,
+            pyright_skip=True,
             install_cmd="{install} $(grep -v mypy mypy-requirements.txt) -r requirements.txt",
             expected_mypy_success=True,
             cost={"mypy": 15},
@@ -923,59 +866,50 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/AlexWaygood/typeshed-stats",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             deps=["attrs", "cattrs", "pytest", "aiohttp", "pathspec", "jinja2", "tomli"],
         ),
         Project(
             location="https://github.com/FasterSpeeding/Tanjun",
             mypy_cmd="{mypy} tanjun",
-            pyright_cmd="{pyright}",
             deps=["hikari", "alluka"],
         ),
         Project(
             location="https://github.com/joerick/pyinstrument",
             mypy_cmd="{mypy} pyinstrument",
-            pyright_cmd="{pyright}",
         ),
         Project(
             location="https://github.com/Gobot1234/steam.py",
             mypy_cmd="{mypy} steam",
-            pyright_cmd="{pyright}",
             deps=["cryptography"],
         ),
         Project(
             location="https://github.com/cpitclaudel/alectryon",
             mypy_cmd="{mypy} alectryon.py",
-            pyright_cmd="{pyright}",
         ),
         Project(
             location="https://github.com/yurijmikhalevich/rclip",
             mypy_cmd="{mypy} rclip --explicit-package-bases",
-            pyright_cmd="{pyright}",
             deps=["numpy", "types-Pillow", "types-requests", "types-tqdm"],
         ),
         Project(
             location="https://github.com/psycopg/psycopg",
             mypy_cmd="{mypy}",
-            pyright_cmd="{pyright}",
             deps=["pytest", "pproxy"],
         ),
         Project(
             location="https://gitlab.com/dkg/python-sop",
             mypy_cmd="{mypy} --strict sop",
-            pyright_cmd="{pyright} sop",
+            paths=["sop"],
         ),
         Project(
             location="https://github.com/Rapptz/discord.py",
             mypy_cmd="{mypy} discord",
-            pyright_cmd="{pyright}",
             deps=["types-requests", "types-setuptools", "aiohttp"],
             cost={"mypy": 20},
         ),
         Project(
             location="https://github.com/canonical/cloud-init",
             mypy_cmd="{mypy} cloudinit/ tests/ tools/",
-            pyright_cmd="{pyright}",
             deps=[
                 "jinja2",
                 "pytest",
@@ -990,13 +924,11 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/mongodb/mongo-python-driver",
             mypy_cmd="{mypy} bson gridfs tools pymongo",
-            pyright_cmd="{pyright}",
             deps=["types-requests", "types-pyOpenSSL", "cryptography", "certifi"],
         ),
         Project(
             location="https://github.com/artigraph/artigraph",
             mypy_cmd="{mypy}",
-            pyright_cmd="{pyright}",
             deps=["pydantic", "numpy", "pytest"],
             needs_mypy_plugins=True,
         ),
@@ -1005,26 +937,22 @@ def get_projects() -> list[Project]:
             mypy_cmd=(
                 "MYPYPATH=$MYPYPATH:misc/python {mypy} --explicit-package-bases ci misc/python"
             ),
-            pyright_cmd="{pyright}",
             install_cmd="{install} -r ci/builder/requirements.txt",
             cost={"mypy": 20},
         ),
         Project(
             location="https://github.com/canonical/operator",
             mypy_cmd="{mypy} ops",
-            pyright_cmd="{pyright}",
             deps=["types-PyYAML"],
         ),
         Project(
             location="https://github.com/astropenguin/xarray-dataclasses",
             mypy_cmd="{mypy} xarray_dataclasses",
-            pyright_cmd="{pyright}",
             deps=["numpy", "xarray"],
         ),
         Project(
             location="https://github.com/caronc/apprise",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             deps=[
                 "types-six",
                 "types-mock",
@@ -1039,19 +967,17 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/Finistere/antidote",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             deps=["pytest"],
         ),
         Project(
             location="https://github.com/cognitedata/Expression",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             deps=["pytest"],
         ),
         Project(
             location="https://github.com/pyodide/pyodide",
             mypy_cmd="{mypy} src pyodide-build --exclude 'setup.py|^src/tests|conftest.py'",
-            pyright_cmd="{pyright} src pyodide-build",
+            paths=["src", "pyodide-build"],
             deps=[
                 "packaging",
                 "types-docutils",
@@ -1065,14 +991,12 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/bokeh/bokeh",
             mypy_cmd="{mypy} src release",
-            pyright_cmd="{pyright}",
             deps=["types-boto", "tornado", "numpy", "jinja2", "selenium"],
             cost={"pyright": 60},
         ),
         Project(
             location="https://github.com/pandas-dev/pandas-stubs",
             mypy_cmd="{mypy} pandas-stubs tests",
-            pyright_cmd="{pyright}",
             deps=[
                 "numpy",
                 "types-pytz",
@@ -1089,20 +1013,19 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/enthought/comtypes",
             mypy_cmd="{mypy} comtypes --platform win32",
-            pyright_cmd="{pyright}",
             deps=["numpy"],
         ),
         Project(
             location="https://github.com/mit-ll-responsible-ai/hydra-zen",
             mypy_cmd="{mypy} src tests/annotations/mypy_checks.py",
-            pyright_cmd="{pyright} tests/annotations src",
+            paths=["tests/annotations", "src"],
             deps=["pydantic", "beartype", "hydra-core"],
             cost={"mypy": 10},
         ),
         Project(
             location="https://github.com/Toufool/AutoSplit",
             mypy_cmd="{mypy} src",
-            pyright_cmd="{pyright} src",
+            paths=["src"],
             deps=[
                 "certifi",
                 "ImageHash",
@@ -1124,7 +1047,6 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/Avasam/speedrun.com_global_scoreboard_webapp",
             mypy_cmd="{mypy} backend",
-            pyright_cmd="{pyright}",
             deps=[
                 "Flask",
                 "PyJWT",
@@ -1137,39 +1059,37 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/pwndbg/pwndbg",
             mypy_cmd="{mypy} pwndbg",
-            pyright_cmd="{pyright}",
             deps=["types-gdb"],
             cost={"mypy": 10, "pyright": 75},
         ),
         Project(
             location="https://github.com/keithasaurus/koda-validate",
             mypy_cmd="{mypy} koda_validate --strict",
-            pyright_cmd="{pyright}",
             deps=["koda"],
         ),
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/clinic/mypy.ini",
-            pyright_cmd=None,
+            pyright_skip=True,
             name_override="CPython (Argument Clinic)",
         ),
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/cases_generator/mypy.ini",
-            pyright_cmd=None,
+            pyright_skip=True,
             name_override="CPython (cases_generator)",
         ),
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/peg_generator/mypy.ini",
-            pyright_cmd=None,
+            pyright_skip=True,
             deps=["types-setuptools", "types-psutil"],
             name_override="CPython (peg_generator)",
         ),
         Project(
             location="https://github.com/python-trio/trio",
             mypy_cmd="{mypy} src/trio",
-            pyright_cmd="{pyright} src/trio",
+            paths=["src/trio"],
             deps=[
                 "types-pyOpenSSL",
                 "types-cffi",
@@ -1183,7 +1103,6 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/pypa/setuptools",
             mypy_cmd="{mypy} setuptools pkg_resources",
-            pyright_cmd="{pyright}",
             deps=[
                 "pytest",
                 "filelock",
@@ -1196,23 +1115,20 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/detachhead/pytest-robotframework",
             mypy_cmd="{mypy} -p pytest_robotframework",
-            pyright_cmd="{pyright}",
         ),
         Project(
             location="https://github.com/mhammond/pywin32",
             mypy_cmd="{mypy} .",
-            pyright_cmd="{pyright}",
             deps=["types-pywin32", "types-regex", "types-setuptools"],
         ),
         Project(
             location="https://github.com/beartype/beartype",
             mypy_cmd="{mypy} beartype",
-            pyright_cmd="{pyright}",
         ),
         Project(
             location="https://github.com/typeddjango/django-stubs",
             mypy_cmd="{mypy} django-stubs",
-            pyright_cmd=None,
+            pyright_skip=True,
             deps=[
                 "django",
                 "asgiref",
@@ -1227,26 +1143,22 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/colour-science/colour",
             mypy_cmd="{mypy} colour",
-            pyright_cmd="{pyright}",
             deps=["numpy", "pytest", "matplotlib", "pandas-stubs"],
             cost={"mypy": 45, "pyright": 180},
         ),
         Project(
             location="https://github.com/vega/altair",
             mypy_cmd="{mypy} altair tests",
-            pyright_cmd="{pyright}",
             deps=["types-jsonschema", "pandas-stubs", "pytest", "narwhals", "packaging", "jinja2"],
         ),
         Project(
             location="https://github.com/hydpy-dev/hydpy",
             mypy_cmd="{mypy} hydpy",
-            pyright_cmd="{pyright}",
             deps=["numpy", "types-docutils"],
         ),
         Project(
             location="https://github.com/static-frame/static-frame",
             mypy_cmd="{mypy} static_frame",
-            pyright_cmd="{pyright}",
             deps=["numpy", "arraykit"],
         ),
     ]


### PR DESCRIPTION
Thank you for creating `mypy_primer`! As of recently, we use it to run test [Red Knot](https://github.com/astral-sh/ruff/blob/main/crates/red_knot/README.md) against (a small subset of) ecosystem projects. So far, we use a [fork](https://github.com/astral-sh/mypy_primer/tree/add-red-knot-support) of `mypy_primer`, but I would like to clean up our implementation, add some improvements, and potentially upstream some of the changes — if you are interested.

As a first step, I would like to propose a change to the `Project` dataclass. So far, it stores a custom `mypy_cmd` and a `pyright_cmd`. I've noticed that the `pyright_cmd` in particular only comes in three variants:
- `pyright_cmd=None` — which means that Pyright shouldn't run for this project
- `pyright_cmd="{pyright}"` — which means that Pyright should be executed without passing any explicit paths
- `pyright_cmd="{pyright} some relative paths"` — which means that the command line includes a list of explicit paths that are passed to Pyright.
In particular, there are no `pyright_cmd` fields that pass additional flags to pyright.

For running other type checkers, it would be beneficial to have that information in a more structured form. This way we could reuse the list of explicit paths. So I'm proposing the following change:

* For projects that previously used `pyright_cmd=None`, we add a new flag `pyright_skip=True`.
* For projects that previously used `pyright_cmd="{pyright}"`, we simply remove that `pyright_cmd` parameter. We consider that to be the new default.
* For projects that previously used `pyright_cmd="{pyright} some relative paths"`, we also remove the `pyright_cmd` parameter and add a new `paths=["some", "relative", "paths"]` field.

I have not attempted to change the representation for mypy, but I could do so if it seems desirable. I'd like to discuss the general approach first.

I tested this by running
```
mypy_primer --type-checker pyright
```