### PR TITLE
Add `scipy-stubs` as project

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -801,6 +801,14 @@ def get_projects() -> list[Project]:
             cost={"mypy": 25},
         ),
         Project(
+            location="https://github.com/scipy/scipy-stubs",
+            mypy_cmd="{mypy}",
+            pyright_cmd="{pyright}",
+            deps=["scipy", "optype"],
+            expected_mypy_success=True,
+            expected_pyright_success=True,
+        ),
+        Project(
             location="https://github.com/pycqa/flake8",
             mypy_cmd="{mypy} src tests",
             pyright_cmd="{pyright}",


### PR DESCRIPTION
It's a pretty beefy stubs-only package with 50k+ lines of (valid) code, so I figured it might be useful to add it here :)