### PR TITLE
add `numpy` to the `deps` of `scipy-stubs`

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -804,7 +804,7 @@ def get_projects() -> list[Project]:
             location="https://github.com/scipy/scipy-stubs",
             mypy_cmd="{mypy}",
             pyright_cmd="{pyright}",
-            deps=["scipy", "optype"],
+            deps=["scipy", "optype", "numpy"],
             expected_mypy_success=True,
             expected_pyright_success=True,
         ),


### PR DESCRIPTION
I left it out earlier because `scipy` already requires `numpy`.

But by explicitly adding `numpy` to `deps`, `scipy-stubs` will also be selected when `--known-dependency-selector=numpy` is passed, as e.g. `numpy` itself does.