### PR TITLE
Fix issues running mypy_primer on Windows

### DIFF
--- a/mypy_primer/main.py
+++ b/mypy_primer/main.py
@@ -71,8 +71,8 @@ async def setup_new_and_old_pyright(
 
     if ctx.get().debug:
         (new_version, _), (old_version, _) = await asyncio.gather(
-            run([str(new_pyright), "--version"], output=True),
-            run([str(old_pyright), "--version"], output=True),
+            run(["node", str(new_pyright), "--version"], output=True),
+            run(["node", str(old_pyright), "--version"], output=True),
         )
         debug_print(f"{Style.BLUE}new pyright version: {new_version.stdout.strip()}{Style.RESET}")
         debug_print(f"{Style.BLUE}old pyright version: {old_version.stdout.strip()}{Style.RESET}")

--- a/mypy_primer/main.py
+++ b/mypy_primer/main.py
@@ -19,7 +19,7 @@ from mypy_primer.globals import ctx, parse_options_and_set_ctx
 from mypy_primer.model import Project, TypeCheckResult
 from mypy_primer.projects import get_projects
 from mypy_primer.type_checker import setup_mypy, setup_pyright, setup_typeshed
-from mypy_primer.utils import Style, debug_print, line_count, run, strip_colour_code
+from mypy_primer.utils import Style, debug_print, get_npm, line_count, run, strip_colour_code
 
 T = TypeVar("T")
 
@@ -319,8 +319,9 @@ async def bisect() -> None:
         await run(["git", "submodule", "update", "--init"], cwd=repo_dir)
 
         if ARGS.type_checker == "pyright":
-            await run(["npm", "run", "install:all"], cwd=repo_dir)
-            await run(["npm", "run", "build"], cwd=repo_dir / "packages" / "pyright")
+            npm = get_npm()
+            await run([npm, "run", "install:all"], cwd=repo_dir)
+            await run([npm, "run", "build"], cwd=repo_dir / "packages" / "pyright")
 
         results_fut = await asyncio.gather(*(run_wrapper(project) for project in projects))
         results: dict[str, TypeCheckResult] = dict(results_fut)

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -263,7 +263,7 @@ class Project:
             env["MYPY_PRIMER_PREPEND_PATH"] = str(prepend_path)
 
         pyright_cmd = self.get_pyright_cmd(pyright, additional_flags)
-        pyright_cmd = f"source {self.venv.activate}; {pyright_cmd}"
+        pyright_cmd = f"{self.venv.activate_cmd} && {pyright_cmd}"
         proc, runtime = await run(
             pyright_cmd,
             shell=True,

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -249,7 +249,7 @@ class Project:
         assert "{pyright}" in pyright_cmd
         if additional_flags:
             pyright_cmd += " " + " ".join(additional_flags)
-        pyright_cmd = pyright_cmd.format(pyright=pyright)
+        pyright_cmd = pyright_cmd.format(pyright=f"node {pyright}")
         return pyright_cmd
 
     async def run_pyright(

--- a/mypy_primer/type_checker.py
+++ b/mypy_primer/type_checker.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from mypy_primer.git_utils import RevisionLike, ensure_repo_at_revision
-from mypy_primer.utils import Venv, has_uv, run
+from mypy_primer.utils import Venv, get_npm, has_uv, run
 
 
 async def setup_mypy(
@@ -92,8 +92,9 @@ async def setup_pyright(
         repo = "https://github.com/microsoft/pyright"
     repo_dir = await ensure_repo_at_revision(repo, pyright_dir, revision_like)
 
-    await run(["npm", "run", "install:all"], cwd=repo_dir)
-    await run(["npm", "run", "build"], cwd=repo_dir / "packages" / "pyright")
+    npm = get_npm()
+    await run([npm, "run", "install:all"], cwd=repo_dir)
+    await run([npm, "run", "build"], cwd=repo_dir / "packages" / "pyright")
 
     pyright_exe = repo_dir / "packages" / "pyright" / "index.js"
     assert pyright_exe.exists()

--- a/mypy_primer/utils.py
+++ b/mypy_primer/utils.py
@@ -173,3 +173,15 @@ def line_count(path: Path) -> int:
             return sum(buf.count(b"\n") for buf in buf_iter)
     except FileNotFoundError:
         return 0
+
+
+def get_npm() -> str:
+    npm_path = shutil.which("npm")
+    if npm_path is None:
+        raise RuntimeError("'npm' is not found.")
+    if sys.platform == "win32":
+        # On Windows, npm is typically installed as 'npm.cmd'
+        # and `subprocess` requires full name for it to run.
+        return Path(npm_path).name
+    else:
+        return "npm"

--- a/mypy_primer/utils.py
+++ b/mypy_primer/utils.py
@@ -150,11 +150,11 @@ class Venv:
             return self.dir / "lib" / pyname / "site-packages"
 
     @property
-    def activate(self) -> Path:
+    def activate_cmd(self) -> str:
         if sys.platform == "win32":
-            return self.bin / "activate.bat"
+            return str(self.bin / "activate.bat")
         else:
-            return self.bin / "activate"
+            return f"source {self.bin / 'activate'}"
 
     async def make_venv(self) -> None:
         if has_uv():

--- a/mypy_primer/utils.py
+++ b/mypy_primer/utils.py
@@ -175,6 +175,7 @@ def line_count(path: Path) -> int:
         return 0
 
 
+@functools.cache
 def get_npm() -> str:
     npm_path = shutil.which("npm")
     if npm_path is None:


### PR DESCRIPTION
1) Use `get_npm()` for `npm` commad as on Windows it tends to be installed as `npm.cmd` and not `npm.exe` and `subprocess` module requires full filename in that case, not just `npm`.

2) Use `node` explicitly in commands that execute .js files instead of relying on shebang.

3) Fix activating npm on Windows:
- ensure `source` used only if it's not Windows
- use `&&` instead `;` to support running it on Windows (on Windows `;` doesn't separate commands but instead second command is passed as an argument to the first one)

There's a little caveat about the last bullet point - was it intended to skip errors with `;`? Tested `&&` on Windows and mypy_primer works fine. But when I was testing `&&` on unix using pyright's workflow, I've found that it no longer works - it seems it was relying on silent errors like the one below (https://github.com/Andrej730/pyright/actions/runs/14158580085/job/39661016528). Which seems odd since it either means next line was executed not inside venv which either may lead to other issues or makes venv activate unnecessary.
```
2025-03-30T18:04:46.6002618Z > source /tmp/mypy_primer/projects/_pydantic_venv/bin/activate; /tmp/mypy_primer/old_pyright/pyright_to_test/packages/pyright/index.js (19.0s)
2025-03-30T18:04:46.6003740Z 	/bin/sh: 1: source: not found
```

@hauntsaninja can you please take a look?
