### PR TITLE
include `packaging` in the `deps` of `scipy-stubs`

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -804,7 +804,7 @@ def get_projects() -> list[Project]:
             location="https://github.com/scipy/scipy-stubs",
             mypy_cmd="{mypy} .",
             pyright_cmd="{pyright}",
-            deps=["scipy", "optype", "numpy"],
+            deps=["numpy", "optype", "packaging", "scipy"],
             expected_mypy_success=True,
             expected_pyright_success=True,
         ),


### PR DESCRIPTION
As I explained in #141, the missing `packaging` package was leading to 43 pyright errors. By adding it, `scipy-stubs` will no longer report any pyright errors (if #141 is fixed), and only 1 mypy error (an invalid error code, which I'll soon fix)