### PR TITLE
add async_utils

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1249,6 +1249,11 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["numpy", "arraykit"],
         ),
+        Project(
+            location="https://github.com/mikeshardmind/async-utils",
+            mypy_cmd="{mypy} src",
+            pyright_cmd="{pyright}",
+        ),
     ]
     assert len(projects) == len({p.name for p in projects})
     for p in projects:


### PR DESCRIPTION
Upstream adding async utils, which was added to Astral's fork for visibility on a project using type alias statements and new generic syntax. (related to prior #146)