### PR TITLE
Add types-setuptools dependency to pybind11.

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -638,7 +638,7 @@ def get_projects() -> list[Project]:
             location="https://github.com/pybind/pybind11",
             mypy_cmd="{mypy} --exclude '^(tests|docs)/' .",
             pyright_cmd="{pyright}",
-            deps=["nox", "rich"],
+            deps=["nox", "rich", "types-setuptools"],
             expected_mypy_success=True,
         ),
         Project(


### PR DESCRIPTION
pybind11 has types-setuptools listed as a dependency that mypy needs: https://github.com/pybind/pybind11/blob/b3bb31ca51c4af3fb1278f917cb9bbbe2336b812/.pre-commit-config.yaml#L52.

When I run `mypy_primer -k pybind11 --type-checker mypy` under Python 3.12, I get 10 errors without types-setuptools as a dep and 0 once I add it.