### PR TITLE
Add 'strawberry' as a project

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1510,6 +1510,13 @@ def get_projects() -> list[Project]:
             deps=["packaging"],
             expected_success=("pyright",),
         ),
+        Project(
+            location="https://github.com/strawberry-graphql/strawberry",
+            mypy_cmd="{mypy} {paths} --config-file=",
+            pyright_cmd="{pyright} {paths}",
+            paths=["strawberry"],
+            deps=["graphql-core", "typing-extensions", "python-dateutil", "packaging"],
+        ),
     ]
     assert len(projects) == len({p.name for p in projects})
     for p in projects:

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1515,7 +1515,7 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} {paths} --config-file=",
             pyright_cmd="{pyright} {paths}",
             paths=["strawberry"],
-            deps=["graphql-core", "typing-extensions", "python-dateutil", "packaging"],
+            deps=["graphql-core", "python-dateutil", "packaging"],
         ),
     ]
     assert len(projects) == len({p.name for p in projects})


### PR DESCRIPTION
When working on `@dataclass_transform` support, I found it helpful to test on [`strawberry`](https://github.com/strawberry-graphql/strawberry), as it makes [heavy use of the feature](https://github.com/search?q=repo%3Astrawberry-graphql%2Fstrawberry%20dataclass_transform&type=code).

The `projects.py` file has a comment on top ("repos with plugins") which lists `strawberry`. I'm not sure if that entry implies anything regarding using it as a project. But I had to set `--config-file=` for mypy (as was done for some other projects), because of some errors when trying to run with `strawberry`'s [`mypy.ini`](https://github.com/strawberry-graphql/strawberry/blob/main/mypy.ini) (related to `--install-types` and `--non-interactive`).

I tested using mypy, pyright, and Red Knot.