### PR TITLE
Add knot_cmd to __repr__

### DIFF
--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -56,6 +56,8 @@ class Project:
             result += f", name_override={self.name_override!r}"
         if self.pyright_cmd:
             result += f", pyright_cmd={self.pyright_cmd!r}"
+        if self.knot_cmd:
+            result += f", knot_cmd={self.knot_cmd!r}"
         if self.paths:
             result += f", paths={self.paths!r}"
         if self.install_cmd:


### PR DESCRIPTION
I was poking at getting pyrefly working and noticed this was missing, I'm guessing it's just an omission from https://github.com/hauntsaninja/mypy_primer/commit/ebaa9fd27b51a278873b63676fd25490cec6823b