### PR TITLE
Rename `knot` to `ty`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ mypy_primer is currently used in the CI of the following projects:
 - pyright
 - basedpyright
 - typeshed
-- red knot
+- ty
 - numpy
 
 It has also inspired similar tooling for other projects in the code quality ecosystem.

--- a/mypy_primer/globals.py
+++ b/mypy_primer/globals.py
@@ -81,7 +81,7 @@ def parse_options(argv: list[str]) -> _Args:
     type_checker_group.add_argument(
         "--type-checker",
         default="mypy",
-        choices=["mypy", "pyright", "knot", "pyrefly"],
+        choices=["mypy", "pyright", "ty", "pyrefly"],
         help="type checker to use",
     )
     type_checker_group.add_argument(

--- a/mypy_primer/main.py
+++ b/mypy_primer/main.py
@@ -19,10 +19,10 @@ from mypy_primer.globals import _Args, parse_options_and_set_ctx
 from mypy_primer.model import Project, TypeCheckResult
 from mypy_primer.projects import get_projects
 from mypy_primer.type_checker import (
-    setup_ty,
     setup_mypy,
     setup_pyrefly,
     setup_pyright,
+    setup_ty,
     setup_typeshed,
 )
 from mypy_primer.utils import Style, debug_print, get_npm, line_count, run, strip_colour_code

--- a/mypy_primer/main.py
+++ b/mypy_primer/main.py
@@ -19,7 +19,7 @@ from mypy_primer.globals import _Args, parse_options_and_set_ctx
 from mypy_primer.model import Project, TypeCheckResult
 from mypy_primer.projects import get_projects
 from mypy_primer.type_checker import (
-    setup_knot,
+    setup_ty,
     setup_mypy,
     setup_pyrefly,
     setup_pyright,
@@ -46,8 +46,8 @@ def setup_type_checker(
     elif ARGS.type_checker == "pyright":
         setup_fn = setup_pyright
         kwargs = {"repo": ARGS.repo}
-    elif ARGS.type_checker == "knot":
-        setup_fn = setup_knot
+    elif ARGS.type_checker == "ty":
+        setup_fn = setup_ty
         kwargs = {"repo": ARGS.repo}
     elif ARGS.type_checker == "pyrefly":
         return setup_pyrefly(
@@ -139,8 +139,8 @@ def select_projects(ARGS: _Args) -> list[Project]:
         project_iter = iter(p for p in project_iter if p.mypy_cmd is not None)
     if ARGS.type_checker == "pyright":
         project_iter = iter(p for p in project_iter if p.pyright_cmd is not None)
-    # if ARGS.type_checker == "knot":
-    #     project_iter = iter(p for p in project_iter if p.knot_cmd is not None)
+    # if ARGS.type_checker == "ty":
+    #     project_iter = iter(p for p in project_iter if p.ty_cmd is not None)
 
     if ARGS.project_selector:
         project_iter = iter(

--- a/mypy_primer/type_checker.py
+++ b/mypy_primer/type_checker.py
@@ -98,39 +98,39 @@ async def setup_pyright(
     return pyright_exe
 
 
-async def setup_knot(
-    knot_dir: Path,
+async def setup_ty(
+    ty_dir: Path,
     revision_like: RevisionLike,
     *,
     repo: str | None,
 ) -> Path:
-    knot_dir.mkdir(parents=True, exist_ok=True)
+    ty_dir.mkdir(parents=True, exist_ok=True)
 
     if repo is None:
         repo = "https://github.com/astral-sh/ruff"
-    repo_dir = await ensure_repo_at_revision(repo, knot_dir, revision_like)
+    repo_dir = await ensure_repo_at_revision(repo, ty_dir, revision_like)
 
-    cargo_target_dir = knot_dir / "target"
+    cargo_target_dir = ty_dir / "target"
     if not os.environ.get("MYPY_PRIMER_NO_REBUILD", False):
         env = os.environ.copy()
         env["CARGO_TARGET_DIR"] = str(cargo_target_dir)
 
         try:
             await run(
-                ["cargo", "build", "--bin", "red_knot"],
+                ["cargo", "build", "--bin", "ty"],
                 cwd=repo_dir,
                 env=env,
                 output=True,
             )
         except subprocess.CalledProcessError as e:
-            print("Error while building 'knot'", file=sys.stderr)
+            print("Error while building 'ty'", file=sys.stderr)
             print(e.stdout, file=sys.stderr)
             print(e.stderr, file=sys.stderr)
             raise e
 
-    knot_exe = cargo_target_dir / "debug" / "red_knot"
-    assert knot_exe.exists()
-    return knot_exe
+    ty_exe = cargo_target_dir / "debug" / "ty"
+    assert ty_exe.exists()
+    return ty_exe
 
 
 async def setup_pyrefly(


### PR DESCRIPTION
This PR renames `knot` to ty. Red Knot was our internal code name but we plan on releasing our type checker using ty

I did a search & replace for knot. I tested that `uv run --project ../mypy_primer/ mypy_primer --type-checker ty --old micha/rename --new micha/rename` succeeds on my rename branch https://github.com/astral-sh/ruff/pull/17820