### PR TITLE
Fix setup of static-frame

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1472,7 +1472,7 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["static_frame"],
-            deps=["numpy", "arraykit"],
+            deps=["numpy", "arraykit==0.10.0"],
         ),
         Project(
             location="https://github.com/mikeshardmind/async-utils",


### PR DESCRIPTION
`static-frame` project setup currently fails with:
```
      src/_arraykit.c:6:11: fatal error: numpy/arrayobject.h: No such file or directory
          6 | # include "numpy/arrayobject.h"
            |           ^~~~~~~~~~~~~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/cc' failed with exit code 1

      hint: This error likely indicates that you need to install a library that provides "numpy/arrayobject.h" for
      `arraykit@1.0.0`
```

I didn't look further into it, but arraykit [just released a new version](https://github.com/static-frame/arraykit/releases), so for now, pinning the dependency at 0.10.0 (the previous version) seems okay. If we decide to go with this, I can open an issue to track this, so we can eventually remove that pin again.