### PR TITLE
psycopg: Configure src.root for ty

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1162,6 +1162,7 @@ def get_projects() -> list[Project]:
             location="https://github.com/psycopg/psycopg",
             mypy_cmd="{mypy}",
             pyright_cmd="{pyright}",
+            ty_cmd="""{ty} check --config 'src.root="./psycopg"'""",
             deps=["pytest", "pproxy"],
         ),
         Project(


### PR DESCRIPTION
As analyzed [here](https://github.com/astral-sh/ruff/pull/18137), psycopg uses a src layout but the src folder is called `psycopg`. This is not supported in ty, unless `src.root` is configured accordingly.