### PR TITLE
Add scikit-build-core

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1600,6 +1600,32 @@ def get_projects() -> list[Project]:
             deps=["cryptography", "pydantic", "pytest"],
             cost={"mypy": 24},
         ),
+        Project(
+            location="https://github.com/scikit-build/scikit-build-core",
+            mypy_cmd="{mypy} {paths}",
+            pyright_cmd="{pyright} {paths}",
+            paths=["src", "tests", "noxfile.py"],
+            deps=[
+                "build",
+                "cattrs",
+                "cmake",
+                "exceptiongroup",
+                "hatch-fancy-pypi-readme",
+                "importlib-resources",
+                "markdown-it-py",
+                "ninja",
+                "nox",
+                "orjson",
+                "packaging",
+                "pytest",
+                "pytest-subprocess",
+                "rich",
+                "setuptools-scm",
+                "tomli",
+                "types-setuptools",
+            ],
+            cost={"mypy": 34},
+        ),
     ]
     assert len(projects) == len({p.name for p in projects})
     for p in projects:


### PR DESCRIPTION
I picked bad timing for this, as it looks like the next version of mypy has issues with it:

```
old
> /tmp/mypy_primer/mypy_old/venv/bin/mypy src tests noxfile.py --python-executable=/tmp/mypy_primer/projects/_scikit-build-core_venv/bin/python --warn-unused-ignores --warn-redundant-casts --no-incremental --cache-dir=/dev/null --show-traceback --soft-error-limit=-1 (27.8s)
	Success: no issues found in 165 source files
----------

new
> /tmp/mypy_primer/mypy_new/venv/bin/mypy src tests noxfile.py --python-executable=/tmp/mypy_primer/projects/_scikit-build-core_venv/bin/python --warn-unused-ignores --warn-redundant-casts --no-incremental --cache-dir=/dev/null --show-traceback --soft-error-limit=-1 (27.9s)
	src/scikit_build_core/settings/sources.py:498: error: "DataclassInstance" not callable  [operator]
	src/scikit_build_core/settings/sources.py:587: error: Argument 1 to "convert_target" of "SourceChain" has incompatible type "Union[Type[DataclassInstance], DataclassInstance]"; expected "Type[DataclassInstance]"  [arg-type]
	src/scikit_build_core/settings/documentation.py:88: error: Unused "type: ignore" comment  [unused-ignore]
	src/scikit_build_core/settings/documentation.py:105: error: Argument 1 to "mk_docs" has incompatible type "Union[Type[DataclassInstance], DataclassInstance]"; expected "Type[object]"  [arg-type]
	src/scikit_build_core/settings/documentation.py:111: error: Argument 1 to "mk_docs" has incompatible type "Union[Type[DataclassInstance], DataclassInstance]"; expected "Type[object]"  [arg-type]
	src/scikit_build_core/file_api/reply.py:98: error: Argument 2 to "make_class" of "Converter" has incompatible type "Union[Type[DataclassInstance], DataclassInstance]"; expected "Type[DataclassInstance]"  [arg-type]
	src/scikit_build_core/settings/json_schema.py:117: error: Argument 1 to "to_json_schema" has incompatible type "Union[DataclassInstance, Type[DataclassInstance]]"; expected "Type[Any]"  [arg-type]
	Found 7 errors in 4 files (checked 165 source files)
```

Not sure what the policy is for projects that were error free in the last released version, I can wait until after release if that's better. Looks like it's not far away: https://github.com/python/mypy/issues/18739.

Edit: I worked around most of the issues.
