### PR TITLE
Fix `colour` cost

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1508,7 +1508,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["colour"],
             deps=["matplotlib", "numpy", "pandas-stubs", "pytest", "scipy-stubs"],
-            cost={"mypy": 2, "pyright": 180},
+            cost={"mypy": 800, "pyright": 180},
         ),
         Project(
             location="https://github.com/vega/altair",


### PR DESCRIPTION
Fixes a mistake I made in https://github.com/hauntsaninja/mypy_primer/pull/170

I'm not too sure this whole saga helped that much as the shards are only *somewhat* clustered around 20~25 minutes (other than the one with `colour`!), but I didn't actually check how badly they were balanced before.