### PR TITLE
Update typeshed stub redaction logic

### DIFF
--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -504,7 +504,7 @@ def _redact_base_dir(output: str, base_dir: Path) -> str:
         r"^(?P<header>[^:]*?)"
         f"(?:{re.escape(str(base_dir.resolve()))}"
         f"|{re.escape(str(base_dir))})"
-        r"(?:[^:]*?_(new|old)/)?(?P<trailer>[^:\s]*(:|$))"
+        r"(?:[^:]*?(new|old)[^/]*/)?(?P<trailer>[^:\s]*(:|$))"
     )
     return re.sub(base_dir_re, r"\g<header>...\g<trailer>", output, flags=re.MULTILINE)
 


### PR DESCRIPTION
The stub reduction logic after #182 has some hiccups with typeshed. See e.g. https://github.com/python/typeshed/pull/14247#issuecomment-2955105133:
```diff
discord.py (https://github.com/Rapptz/discord.py)
- .../old_typeshed/typeshed_to_test/stdlib/typing.pyi:1014: note: "update" of "TypedDict" defined here
+ .../new_typeshed/typeshed_to_test/stdlib/typing.pyi:1014: note: "update" of "TypedDict" defined here
- .../old_typeshed/typeshed_to_test/stdlib/typing.pyi:1014: note: "update" of "TypedDict" defined here
+ .../new_typeshed/typeshed_to_test/stdlib/typing.pyi:1014: note: "update" of "TypedDict" defined here
```
