### PR TITLE
Remove `psycopg` config override for ty

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1212,7 +1212,6 @@ def get_projects() -> list[Project]:
             location="https://github.com/psycopg/psycopg",
             mypy_cmd="{mypy}",
             pyright_cmd="{pyright}",
-            ty_cmd="""{ty} check --config 'src.root="./psycopg"'""",
             deps=["pytest", "pproxy"],
             cost={"mypy": 28},
         ),


### PR DESCRIPTION
We renamed the option to `environment.root` but it's also no longer necessary because ty defaults to include `<project_root>/<project_name>` by default if `environment.root` is left unspecified

## Test plan

I verified that there are now fewer diagnostics (because we include `tests`) without the override than there were with the configuration override.
