### PR TITLE
Fix mypy primer for Pyrefly

### DIFF
--- a/mypy_primer/main.py
+++ b/mypy_primer/main.py
@@ -50,12 +50,8 @@ def setup_type_checker(
         setup_fn = setup_ty
         kwargs = {"repo": ARGS.repo}
     elif ARGS.type_checker == "pyrefly":
-        return setup_pyrefly(
-            ARGS.base_dir / f"{ARGS.type_checker}_{suffix}",
-            revision_like=revision_like,
-            repo=ARGS.repo,
-            typeshed_dir=typeshed_dir,
-        )
+        setup_fn = setup_pyrefly
+        kwargs = {"repo": ARGS.repo, "typeshed_dir": typeshed_dir}
     else:
         raise ValueError(f"Unknown type checker {ARGS.type_checker}")
 

--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -351,7 +351,7 @@ class Project:
 
         pyrefly_cmd = pyrefly_cmd.format_map(_FormatMap(pyrefly=pyrefly, paths=self.paths))
 
-        pyrefly_cmd += f" --python-interpreter {quote_path(self.venv.dir)}/bin/python"
+        pyrefly_cmd += f" --python-interpreter {quote_path(self.venv.dir)}/bin/python --no-summary --output-format min-text"
         return pyrefly_cmd
 
     async def run_pyrefly(

--- a/mypy_primer/type_checker.py
+++ b/mypy_primer/type_checker.py
@@ -162,7 +162,7 @@ async def setup_pyrefly(
         try:
             await run(
                 ["cargo", "build", "--release"],
-                cwd=pyrefly_dir / "pyrefly",
+                cwd=repo_dir / "pyrefly",
                 env=env,
                 output=True,
             )
@@ -172,7 +172,7 @@ async def setup_pyrefly(
             print(e.stderr, file=sys.stderr)
             raise e
 
-    pyrefly_exe = pyrefly_dir / "pyrefly" / "target" / "release" / "pyrefly"
+    pyrefly_exe = repo_dir / "target" / "release" / "pyrefly"
     assert pyrefly_exe.exists()
     return pyrefly_exe
 

--- a/mypy_primer/type_checker.py
+++ b/mypy_primer/type_checker.py
@@ -162,7 +162,7 @@ async def setup_pyrefly(
         try:
             await run(
                 ["cargo", "build", "--release"],
-                cwd=repo_dir / "pyrefly",
+                cwd=pyrefly_dir / "pyrefly",
                 env=env,
                 output=True,
             )
@@ -172,7 +172,7 @@ async def setup_pyrefly(
             print(e.stderr, file=sys.stderr)
             raise e
 
-    pyrefly_exe = repo_dir / "pyrefly" / "target" / "release" / "pyrefly"
+    pyrefly_exe = pyrefly_dir / "pyrefly" / "target" / "release" / "pyrefly"
     assert pyrefly_exe.exists()
     return pyrefly_exe
 


### PR DESCRIPTION
A couple of adjustments:
- make the configuration logic match the other checkers
- don't show code snippets or summary for emitted errors
- fix the path for the built binary

Tested on https://github.com/facebook/pyrefly/pull/565

Unrelated: even though the "run pyrefly on mypy primer" job succeeds, I can't seem to get the "comment on the PR" job to trigger - do I need a special setup for that?