### PR TITLE
Add `DateType`

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1625,6 +1625,13 @@ def get_projects() -> list[Project]:
             deps=["attrs", "flask", "aiohttp", "fastapi", "starlette"],
             expected_success=("mypy", "pyright"),
         ),
+        Project(
+            location="https://github.com/glyph/DateType",
+            mypy_cmd="{mypy} {paths}",
+            pyright_cmd="{pyright} {paths}",
+            paths=["src"],
+            expected_success=("mypy",),
+        ),
     ]
     assert len(projects) == len({p.name for p in projects})
     for p in projects:


### PR DESCRIPTION
`DateType` is a small project with no third-party dependencies, but it contains some huge protocols in it that can cause performance issues for type-checking. I nearly landed a [change](https://github.com/astral-sh/ruff/pull/18659) to our (WIP) `Protocol` implementation in ty that would have made us never finish when type-checking this library because it would have made our performance so bad on large protocols; I only stumbled across the issue by chance because I happened to accidentally run ty on the contents of a virtual environment that had `DateType` installed in it. If `DateType` had been included as a mypy_primer project, I'd have spotted the issue much sooner!