### PR TITLE
increased weight of colour from 800 to 1500

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1499,7 +1499,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["colour"],
             deps=["matplotlib", "numpy", "pandas-stubs", "pytest", "scipy-stubs"],
-            cost={"mypy": 800, "pyright": 180},
+            cost={"mypy": 1500, "pyright": 180},
         ),
         Project(
             location="https://github.com/vega/altair",


### PR DESCRIPTION
Fixes #190.

Based on some recent CI runs, the runtime, relative to `aiohttp` is

- <https://github.com/python/mypy/actions/runs/16151424794/job/45583389688?pr=19399>: 3058.76 / 43.02 ≈ 71.10
- <https://github.com/python/mypy/actions/runs/16093224814/job/45412524042?pr=19382>: 3070.90 / 41.84 ≈ 73.39
- <https://github.com/python/mypy/actions/runs/16065502177/job/45339190765?pr=19374>: 3157.65 / 41.94 ≈ 75.28
- <https://github.com/python/mypy/actions/runs/16139070578/job/45542067034?pr=19397>: 3372.30 / 41.35 ≈ 81.55

So, I reweighted from 800 to 75×cost(aiohttp) = 75×20=1500.