### PR TITLE
Retune costs for mypy

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -307,6 +307,9 @@ def get_projects() -> list[Project]:
                 "cryptography",
                 "django-stubs",
             ],
+            # TODO: the plugin here is a little involved and might only work on linux
+            # figure out what it would take to make it actually work
+            # needs_mypy_plugins=True,
             expected_success=("mypy",),
             cost={"pyright": 60, "mypy": 173},
         ),

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -71,7 +71,7 @@ def get_projects() -> list[Project]:
             paths=["mypy", "mypyc"],
             deps=["pytest", "types-psutil", "types-setuptools", "filelock", "tomli"],
             expected_success=("mypy",),
-            cost={"mypy": 55, "pyright": 50},
+            cost={"mypy": 82, "pyright": 50},
         ),
         Project(
             location="https://github.com/hauntsaninja/mypy_primer",
@@ -79,7 +79,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 7},
+            cost={"mypy": 12},
         ),
         Project(
             location="https://github.com/psf/black",
@@ -88,7 +88,7 @@ def get_projects() -> list[Project]:
             paths=["src"],
             deps=["aiohttp", "click", "pathspec", "tomli", "platformdirs", "packaging"],
             expected_success=("mypy",),
-            cost={"mypy": 20},
+            cost={"mypy": 31},
         ),
         Project(
             location="https://github.com/hauntsaninja/pyp",
@@ -96,7 +96,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             expected_success=("mypy",),
-            cost={"mypy": 4},
+            cost={"mypy": 8},
         ),
         Project(
             location="https://github.com/pytest-dev/pytest",
@@ -105,7 +105,7 @@ def get_projects() -> list[Project]:
             paths=["src", "testing"],
             deps=["attrs", "pluggy", "py", "types-setuptools"],
             expected_success=("mypy",),
-            cost={"mypy": 32},
+            cost={"mypy": 47},
         ),
         Project(
             location="https://github.com/pandas-dev/pandas",
@@ -121,7 +121,7 @@ def get_projects() -> list[Project]:
                 "pytest",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 197},
+            cost={"mypy": 355},
         ),
         Project(
             location="https://github.com/pycqa/pylint",
@@ -130,7 +130,7 @@ def get_projects() -> list[Project]:
             paths=["pylint/checkers"],
             deps=["types-toml"],
             expected_success=("mypy",),
-            cost={"mypy": 18},
+            cost={"mypy": 35},
         ),
         Project(
             location="https://github.com/aio-libs/aiohttp",
@@ -140,7 +140,7 @@ def get_projects() -> list[Project]:
             install_cmd="AIOHTTP_NO_EXTENSIONS=1 {install} -e .",
             deps=["pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 20},
+            cost={"mypy": 34},
             supported_platforms=["linux", "darwin"],
         ),
         Project(
@@ -148,7 +148,7 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} src/attr/__init__.pyi src/attr/_version_info.pyi src/attr/converters.pyi src/attr/exceptions.pyi src/attr/filters.pyi src/attr/setters.pyi src/attr/validators.pyi tests/typing_example.py",
             pyright_cmd="{pyright}",
             expected_success=("mypy",),
-            cost={"mypy": 5},
+            cost={"mypy": 9},
         ),
         Project(
             location="https://github.com/sphinx-doc/sphinx",
@@ -156,7 +156,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["sphinx"],
             deps=["babel", "docutils-stubs", "types-requests", "packaging", "jinja2"],
-            cost={"mypy": 35},
+            cost={"mypy": 125},
         ),
         Project(
             location="https://github.com/scikit-learn/scikit-learn",
@@ -165,7 +165,7 @@ def get_projects() -> list[Project]:
             paths=["sklearn"],
             deps=["joblib", "numpy", "scipy-stubs", "threadpoolctl"],
             expected_success=("mypy",),
-            cost={"mypy": 108, "pyright": 240},
+            cost={"mypy": 138, "pyright": 240},
         ),
         Project(
             location="https://github.com/pypa/bandersnatch",
@@ -174,7 +174,7 @@ def get_projects() -> list[Project]:
             paths=["src"],
             deps=["types-filelock", "types-freezegun", "types-setuptools"],
             expected_success=("mypy",),
-            cost={"mypy": 12},
+            cost={"mypy": 18},
         ),
         Project(
             location="https://github.com/hauntsaninja/boostedblob",
@@ -183,7 +183,7 @@ def get_projects() -> list[Project]:
             paths=["boostedblob"],
             deps=["aiohttp", "uvloop", "pycryptodome"],
             expected_success=("mypy",),
-            cost={"mypy": 17},
+            cost={"mypy": 24},
             supported_platforms=["linux", "darwin"],
         ),
         Project(
@@ -193,7 +193,7 @@ def get_projects() -> list[Project]:
             paths=["asynq"],
             deps=["qcore", "pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 12},
+            cost={"mypy": 19},
         ),
         Project(
             location="https://github.com/scrapy/scrapy",
@@ -202,7 +202,7 @@ def get_projects() -> list[Project]:
             paths=["."],
             deps=["attrs", "types-pyOpenSSL", "types-setuptools"],
             expected_success=("mypy",),
-            cost={"mypy": 23},
+            cost={"mypy": 36},
         ),
         Project(
             location="https://github.com/pypa/twine",
@@ -211,7 +211,7 @@ def get_projects() -> list[Project]:
             paths=["twine"],
             deps=["keyring", "types-requests", "rich", "packaging"],
             expected_success=("mypy",),
-            cost={"mypy": 13},
+            cost={"mypy": 21},
         ),
         Project(
             location="https://github.com/more-itertools/more-itertools",
@@ -219,7 +219,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["more_itertools"],
             expected_success=("mypy",),
-            cost={"mypy": 5},
+            cost={"mypy": 8},
         ),
         Project(
             location="https://github.com/pydata/xarray",
@@ -246,7 +246,7 @@ def get_projects() -> list[Project]:
                 "types-setuptools",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 140, "pyright": 170},
+            cost={"mypy": 223, "pyright": 170},
         ),
         Project(
             location="https://github.com/pallets/werkzeug",
@@ -255,7 +255,7 @@ def get_projects() -> list[Project]:
             paths=["src/werkzeug", "tests"],
             deps=["types-setuptools", "pytest", "markupsafe"],
             expected_success=("mypy",),
-            cost={"mypy": 21},
+            cost={"mypy": 32},
         ),
         Project(
             location="https://github.com/pallets/jinja",
@@ -263,7 +263,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["markupsafe"],
             expected_success=("mypy",),
-            cost={"mypy": 11},
+            cost={"mypy": 16},
         ),
         Project(
             location="https://github.com/mystor/git-revise",
@@ -271,7 +271,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["gitrevise"],
             expected_success=("mypy",),
-            cost={"mypy": 5},
+            cost={"mypy": 7},
         ),
         Project(
             location="https://github.com/PyGithub/PyGithub",
@@ -280,7 +280,7 @@ def get_projects() -> list[Project]:
             paths=["github", "tests"],
             deps=["types-requests", "pyjwt"],
             expected_success=("mypy",),
-            cost={"mypy": 18},
+            cost={"mypy": 28},
         ),
         Project(
             location="https://github.com/we-like-parsers/pegen",
@@ -288,7 +288,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src/pegen"],
             expected_success=("mypy",),
-            cost={"mypy": 6},
+            cost={"mypy": 8},
         ),
         Project(
             location="https://github.com/zulip/zulip",
@@ -307,11 +307,8 @@ def get_projects() -> list[Project]:
                 "cryptography",
                 "django-stubs",
             ],
-            # TODO: the plugin here is a little involved and might only work on linux
-            # figure out what it would take to make it actually work
-            # needs_mypy_plugins=True,
             expected_success=("mypy",),
-            cost={"pyright": 60, "mypy": 102},
+            cost={"pyright": 60, "mypy": 173},
         ),
         Project(
             location="https://github.com/dropbox/stone",
@@ -320,7 +317,7 @@ def get_projects() -> list[Project]:
             paths=["stone", "test"],
             deps=["types-six"],
             expected_success=("mypy",),
-            cost={"mypy": 12},
+            cost={"mypy": 18},
         ),
         Project(
             location="https://github.com/yelp/paasta",
@@ -339,7 +336,7 @@ def get_projects() -> list[Project]:
                 "types-tzlocal",
                 "types-ujson",
             ],
-            cost={"mypy": 20},
+            cost={"mypy": 31},
             supported_platforms=["linux", "darwin"],
         ),
         Project(
@@ -361,7 +358,7 @@ def get_projects() -> list[Project]:
                 "pydantic",
             ],
             needs_mypy_plugins=True,
-            cost={"mypy": 36, "pyright": 60},
+            cost={"mypy": 56, "pyright": 60},
         ),
         Project(
             location="https://github.com/pallets/itsdangerous",
@@ -370,7 +367,7 @@ def get_projects() -> list[Project]:
             paths=["src/itsdangerous"],
             deps=["pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 5},
+            cost={"mypy": 7},
         ),
         Project(
             location="https://github.com/jab/bidict",
@@ -378,7 +375,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["bidict"],
             expected_success=("mypy",),
-            cost={"mypy": 5},
+            cost={"mypy": 7},
         ),
         Project(
             location="https://github.com/jaraco/zipp",
@@ -386,7 +383,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["zipp"],
             expected_success=("mypy",),
-            cost={"mypy": 5},
+            cost={"mypy": 7},
         ),
         Project(
             location="https://github.com/aaugustin/websockets",
@@ -395,7 +392,7 @@ def get_projects() -> list[Project]:
             paths=["src"],
             deps=["werkzeug"],
             expected_success=("mypy",),
-            cost={"mypy": 13},
+            cost={"mypy": 21},
         ),
         Project(
             location="https://github.com/pycqa/isort",
@@ -404,14 +401,14 @@ def get_projects() -> list[Project]:
             paths=["isort"],
             deps=["types-setuptools"],
             expected_success=("mypy",),
-            cost={"mypy": 10},
+            cost={"mypy": 15},
         ),
         Project(
             location="https://github.com/aio-libs/aioredis",
             mypy_cmd="{mypy} {paths} --ignore-missing-imports",
             pyright_cmd="{pyright} {paths}",
             paths=["aioredis"],
-            cost={"mypy": 9},
+            cost={"mypy": 14},
         ),
         Project(
             location="https://github.com/agronholm/anyio",
@@ -419,7 +416,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
             expected_success=("mypy",),
-            cost={"mypy": 9},
+            cost={"mypy": 29},
         ),
         Project(
             location="https://github.com/aio-libs/yarl",
@@ -428,7 +425,7 @@ def get_projects() -> list[Project]:
             paths=["yarl", "tests"],
             deps=["multidict", "pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 14},
+            cost={"mypy": 25},
         ),
         Project(
             location="https://github.com/freqtrade/freqtrade",
@@ -448,7 +445,7 @@ def get_projects() -> list[Project]:
             ],
             needs_mypy_plugins=True,
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 95},
+            cost={"mypy": 137},
         ),
         Project(
             location="https://github.com/google/jax",
@@ -457,7 +454,7 @@ def get_projects() -> list[Project]:
             paths=["jax"],
             deps=["ml_dtypes", "numpy", "scipy-stubs", "types-requests"],
             expected_success=("mypy",),
-            cost={"mypy": 178, "pyright": 90},
+            cost={"mypy": 316, "pyright": 90},
         ),
         Project(
             location="https://github.com/dulwich/dulwich",
@@ -466,7 +463,7 @@ def get_projects() -> list[Project]:
             paths=["dulwich"],
             deps=["types-certifi", "types-paramiko", "types-requests"],
             expected_success=("mypy",),
-            cost={"mypy": 15},
+            cost={"mypy": 34},
         ),
         Project(
             location="https://github.com/optuna/optuna",
@@ -485,7 +482,7 @@ def get_projects() -> list[Project]:
                 "typing-extensions",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 101, "pyright": 70},
+            cost={"mypy": 117, "pyright": 70},
         ),
         Project(
             location="https://github.com/trailofbits/manticore",
@@ -493,7 +490,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["types-protobuf", "types-PyYAML", "types-redis", "types-setuptools"],
             expected_success=("mypy",),
-            cost={"mypy": 50, "pyright": 75},
+            cost={"mypy": 79, "pyright": 75},
         ),
         Project(
             location="https://github.com/aiortc/aiortc",
@@ -502,7 +499,7 @@ def get_projects() -> list[Project]:
             paths=["src"],
             deps=["cryptography", "types-pyOpenSSL"],
             expected_success=("mypy",),
-            cost={"mypy": 11},
+            cost={"mypy": 17},
         ),
         Project(
             location="https://github.com/Textualize/rich",
@@ -510,7 +507,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["attrs"],
             expected_success=("mypy",),
-            cost={"mypy": 12},
+            cost={"mypy": 19},
         ),
         Project(
             location="https://github.com/dedupeio/dedupe",
@@ -520,7 +517,7 @@ def get_projects() -> list[Project]:
             deps=["numpy"],
             needs_mypy_plugins=True,
             expected_success=("mypy",),
-            cost={"mypy": 27},
+            cost={"mypy": 35},
         ),
         Project(
             location="https://github.com/schemathesis/schemathesis",
@@ -529,7 +526,7 @@ def get_projects() -> list[Project]:
             paths=["src/schemathesis"],
             deps=["attrs", "types-requests", "types-PyYAML", "hypothesis"],
             expected_success=("mypy",),
-            cost={"mypy": 24},
+            cost={"mypy": 33},
             supported_platforms=["linux", "darwin"],
         ),
         Project(
@@ -539,7 +536,7 @@ def get_projects() -> list[Project]:
             paths=["src", "tests"],
             deps=["pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 110},
+            cost={"mypy": 56},
         ),
         Project(
             location="https://github.com/Legrandin/pycryptodome",
@@ -548,7 +545,7 @@ def get_projects() -> list[Project]:
             paths=["lib"],
             deps=["pycryptodome-test-vectors"],
             expected_success=("mypy",),
-            cost={"mypy": 11},
+            cost={"mypy": 17},
         ),
         Project(
             location="https://github.com/niklasf/python-chess",
@@ -556,7 +553,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["chess"],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 12},
+            cost={"mypy": 19},
         ),
         Project(
             location="https://github.com/pytorch/ignite",
@@ -564,11 +561,11 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["packaging"],
             expected_success=("mypy",),
-            cost={"pyright": 50, "mypy": 11},
+            cost={"pyright": 50, "mypy": 19},
         ),
         Project(
             location="https://github.com/pytorch/vision",
-            mypy_cmd=None,  # "{mypy}",
+            mypy_cmd=None,
             pyright_cmd="{pyright}",
             deps=["numpy", "pillow"],
             cost={"pyright": 50},
@@ -579,7 +576,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
             expected_success=("mypy",),
-            cost={"mypy": 6},
+            cost={"mypy": 9},
         ),
         Project(
             location="https://github.com/pydantic/pydantic",
@@ -588,7 +585,7 @@ def get_projects() -> list[Project]:
             paths=["pydantic"],
             deps=["annotated-types", "pydantic-core", "typing-extensions", "typing-inspection"],
             expected_success=("mypy",),
-            cost={"mypy": 18},
+            cost={"mypy": 29},
         ),
         Project(
             location="https://github.com/encode/starlette",
@@ -597,7 +594,7 @@ def get_projects() -> list[Project]:
             paths=["starlette", "tests"],
             deps=["anyio", "types-requests", "types-PyYAML"],
             expected_success=("mypy",),
-            cost={"mypy": 16},
+            cost={"mypy": 41},
         ),
         Project(
             location="https://github.com/aio-libs/janus",
@@ -605,7 +602,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["janus"],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 7},
+            cost={"mypy": 10},
         ),
         Project(
             location="https://github.com/alerta/alerta",
@@ -614,7 +611,7 @@ def get_projects() -> list[Project]:
             paths=["alerta", "tests"],
             deps=["types-PyYAML", "types-setuptools", "types-requests", "types-pytz"],
             expected_success=("mypy",),
-            cost={"mypy": 15},
+            cost={"mypy": 21},
         ),
         Project(
             location="https://github.com/nolar/kopf",
@@ -623,7 +620,7 @@ def get_projects() -> list[Project]:
             paths=["kopf"],
             deps=["types-setuptools", "types-PyYAML"],
             expected_success=("mypy",),
-            cost={"mypy": 12},
+            cost={"mypy": 19},
         ),
         Project(
             location="https://github.com/davidhalter/parso",
@@ -631,7 +628,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["parso"],
             expected_success=("mypy",),
-            cost={"pyright": 75, "mypy": 7},
+            cost={"pyright": 75, "mypy": 10},
         ),
         Project(
             location="https://github.com/konradhalas/dacite",
@@ -639,14 +636,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["dacite"],
             expected_success=("mypy",),
-            cost={"mypy": 5},
+            cost={"mypy": 7},
         ),
         Project(
             location="https://github.com/ilevkivskyi/com2ann",
             mypy_cmd="{mypy} --python-version=3.9 src/com2ann.py src/test_com2ann.py",
             pyright_cmd="{pyright}",
             expected_success=("mypy",),
-            cost={"mypy": 7},
+            cost={"mypy": 10},
         ),
         Project(
             location="https://github.com/srittau/python-htmlgen",
@@ -655,7 +652,7 @@ def get_projects() -> list[Project]:
             paths=["htmlgen", "test_htmlgen"],
             deps=["asserts"],
             expected_success=("mypy",),
-            cost={"mypy": 8},
+            cost={"mypy": 13},
         ),
         Project(
             location="https://github.com/mitmproxy/mitmproxy",
@@ -664,7 +661,7 @@ def get_projects() -> list[Project]:
             paths=["."],
             deps=["types-requests", "types-pyOpenSSL"],
             expected_success=("mypy",),
-            cost={"mypy": 25},
+            cost={"mypy": 41},
         ),
         Project(
             location="https://github.com/jpadilla/pyjwt",
@@ -673,7 +670,7 @@ def get_projects() -> list[Project]:
             paths=["jwt"],
             deps=["cryptography"],
             expected_success=("mypy",),
-            cost={"mypy": 7},
+            cost={"mypy": 11},
         ),
         Project(
             location="https://github.com/apache/spark",
@@ -682,14 +679,14 @@ def get_projects() -> list[Project]:
             paths=["python/pyspark"],
             deps=["numpy", "pandas-stubs"],
             expected_success=("mypy",),
-            cost={"mypy": 61, "pyright": 110},
+            cost={"mypy": 144, "pyright": 110},
         ),
         Project(
             location="https://github.com/laowantong/paroxython",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["paroxython"],
-            cost={"mypy": 6},
+            cost={"mypy": 9},
         ),
         Project(
             location="https://github.com/Akuli/porcupine",
@@ -707,7 +704,7 @@ def get_projects() -> list[Project]:
                 "types-tree-sitter",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 16},
+            cost={"mypy": 23},
         ),
         Project(
             location="https://github.com/dropbox/mypy-protobuf",
@@ -715,14 +712,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["types-protobuf"],
             expected_success=("mypy",),
-            cost={"mypy": 5},
+            cost={"mypy": 9},
         ),
         Project(
             location="https://github.com/spack/spack",
             mypy_cmd="{mypy} -p spack -p llnl",
             pyright_cmd="{pyright}",
             expected_success=("mypy",),
-            cost={"mypy": 54, "pyright": 100},
+            cost={"mypy": 65, "pyright": 100},
         ),
         Project(
             location="https://github.com/johtso/httpx-caching",
@@ -731,14 +728,14 @@ def get_projects() -> list[Project]:
             paths=["."],
             deps=["types-freezegun", "types-mock", "httpx", "anyio", "pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 16},
+            cost={"mypy": 40},
         ),
         Project(
             location="https://github.com/python-poetry/poetry",
             mypy_cmd="{mypy}",
             pyright_cmd="{pyright}",
             deps=["types-requests", "pytest"],
-            cost={"mypy": 30},
+            cost={"mypy": 63},
         ),
         Project(
             location="https://github.com/awslabs/sockeye",
@@ -746,7 +743,7 @@ def get_projects() -> list[Project]:
             pyright_cmd=None,
             deps=["types-PyYAML"],
             expected_success=("mypy",),
-            cost={"mypy": 14},
+            cost={"mypy": 16},
         ),
         Project(
             location="https://github.com/wntrblm/nox",
@@ -766,7 +763,7 @@ def get_projects() -> list[Project]:
                 "uv",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 12},
+            cost={"mypy": 18},
         ),
         Project(
             location="https://github.com/pandera-dev/pandera",
@@ -786,14 +783,14 @@ def get_projects() -> list[Project]:
                 "typing-inspect",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 53},
+            cost={"mypy": 194},
         ),
         Project(
             location="https://gitlab.com/cki-project/cki-lib",
             mypy_cmd="{mypy} --strict .",
             pyright_cmd="{pyright}",
             deps=["types-PyYAML", "cibuildwheel", "types-requests"],
-            cost={"mypy": 13},
+            cost={"mypy": 20},
         ),
         Project(
             location="https://github.com/python-jsonschema/check-jsonschema",
@@ -802,7 +799,7 @@ def get_projects() -> list[Project]:
             paths=["src"],
             deps=["types-jsonschema", "types-requests"],
             expected_success=("mypy",),
-            cost={"mypy": 9},
+            cost={"mypy": 13},
         ),
         Project(
             location="https://github.com/pybind/pybind11",
@@ -810,7 +807,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["nox", "rich", "types-setuptools"],
             expected_success=("mypy",),
-            cost={"mypy": 13},
+            cost={"mypy": 19},
         ),
         Project(
             location="https://github.com/rpdelaney/downforeveryone",
@@ -819,7 +816,7 @@ def get_projects() -> list[Project]:
             paths=["."],
             deps=["types-requests", "pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 13},
+            cost={"mypy": 21},
         ),
         Project(
             location="https://github.com/DataDog/dd-trace-py",
@@ -836,7 +833,7 @@ def get_projects() -> list[Project]:
             ],
             needs_mypy_plugins=True,
             expected_success=("mypy",),
-            cost={"pyright": 75, "mypy": 31},
+            cost={"pyright": 75, "mypy": 49},
         ),
         Project(
             location="https://github.com/systemd/mkosi",
@@ -845,7 +842,7 @@ def get_projects() -> list[Project]:
             paths=["mkosi"],
             deps=["cryptography"],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 16},
+            cost={"mypy": 23},
         ),
         Project(
             location="https://github.com/sympy/sympy",
@@ -854,14 +851,14 @@ def get_projects() -> list[Project]:
             paths=["sympy"],
             deps=["mpmath"],
             expected_success=("mypy",),
-            cost={"mypy": 127, "pyright": 240},
+            cost={"mypy": 182, "pyright": 240},
         ),
         Project(
             location="https://github.com/nion-software/nionutils",
             mypy_cmd="{mypy} --strict -p nion.utils --config-file=",
             pyright_cmd="{pyright}",
             expected_success=("mypy",),
-            cost={"mypy": 7},
+            cost={"mypy": 14},
         ),
         Project(
             location="https://github.com/PyCQA/flake8-pyi",
@@ -870,7 +867,7 @@ def get_projects() -> list[Project]:
             paths=["flake8_pyi"],
             deps=["types-pyflakes"],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 6},
+            cost={"mypy": 9},
         ),
         Project(
             location="https://github.com/internetarchive/openlibrary",
@@ -885,7 +882,7 @@ def get_projects() -> list[Project]:
                 "types-Deprecated",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 23},
+            cost={"mypy": 34},
         ),
         Project(
             location="https://github.com/JohannesBuchner/imagehash",
@@ -894,7 +891,7 @@ def get_projects() -> list[Project]:
             paths=["imagehash"],
             deps=["PyWavelets", "numpy", "scipy-stubs", "types-Pillow"],
             expected_success=("mypy",),
-            cost={"mypy": 43},
+            cost={"mypy": 96},
         ),
         Project(
             location="https://github.com/Kalmat/PyWinCtl",
@@ -902,7 +899,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src/pywinctl"],
             deps=["types-setuptools", "types-pywin32", "types-python-xlib"],
-            cost={"mypy": 9},
+            cost={"mypy": 14},
         ),
         Project(
             location="https://github.com/mesonbuild/meson",
@@ -910,7 +907,7 @@ def get_projects() -> list[Project]:
             pyright_cmd=None,
             deps=["types-PyYAML", "coverage", "types-chevron", "types-PyYAML", "types-tqdm"],
             expected_success=("mypy",),
-            cost={"mypy": 43},
+            cost={"mypy": 67},
         ),
         Project(
             location="https://github.com/aio-libs/aiohttp-devtools",
@@ -918,7 +915,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["aiohttp", "watchfiles", "types-pygments"],
             expected_success=("mypy",),
-            cost={"mypy": 16},
+            cost={"mypy": 41},
         ),
         Project(
             location="https://github.com/sco1/pylox",
@@ -927,7 +924,7 @@ def get_projects() -> list[Project]:
             paths=["."],
             deps=["attrs", "pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 13},
+            cost={"mypy": 21},
             min_python_version=(3, 10),
         ),
         Project(
@@ -937,7 +934,7 @@ def get_projects() -> list[Project]:
             paths=["ppb_vector", "tests"],
             deps=["hypothesis"],
             expected_success=("mypy",),
-            cost={"mypy": 14},
+            cost={"mypy": 20},
             min_python_version=(3, 10),
         ),
         Project(
@@ -959,7 +956,7 @@ def get_projects() -> list[Project]:
                 "packaging",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 17},
+            cost={"mypy": 26},
         ),
         Project(
             location="https://github.com/astropenguin/xarray-dataclasses",
@@ -968,7 +965,7 @@ def get_projects() -> list[Project]:
             paths=["xarray_dataclasses"],
             deps=["numpy", "xarray"],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 5},
+            cost={"mypy": 7},
         ),
         Project(
             location="https://github.com/scipy/scipy-stubs",
@@ -977,7 +974,7 @@ def get_projects() -> list[Project]:
             paths=["."],
             deps=["numpy", "optype", "packaging", "scipy"],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 111},
+            cost={"mypy": 294},
         ),
         Project(
             location="https://github.com/typeddjango/django-stubs",
@@ -987,7 +984,7 @@ def get_projects() -> list[Project]:
             deps=["asgiref", "django-stubs-ext", "django", "redis", "tomli", "types-PyYAML"],
             needs_mypy_plugins=True,
             expected_success=("mypy",),
-            cost={"mypy": 19},
+            cost={"mypy": 32},
         ),
         Project(
             location="https://github.com/pyppeteer/pyppeteer",
@@ -995,14 +992,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["pyppeteer"],
             install_cmd="{install} .",
-            cost={"mypy": 10},
+            cost={"mypy": 17},
         ),
         Project(
             location="https://github.com/pypa/pip",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
-            cost={"pyright": 45, "mypy": 24},
+            cost={"pyright": 45, "mypy": 36},
         ),
         Project(
             location="https://github.com/tornadoweb/tornado",
@@ -1010,7 +1007,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["tornado"],
             deps=["types-contextvars", "types-pycurl"],
-            cost={"mypy": 17},
+            cost={"mypy": 40},
         ),
         Project(
             location="https://github.com/scipy/scipy",
@@ -1018,7 +1015,7 @@ def get_projects() -> list[Project]:
             pyright_cmd=None,
             deps=["numpy", "pytest", "hypothesis", "setuptools>=71.1", "types-psutil"],
             needs_mypy_plugins=True,
-            cost={"mypy": 80},
+            cost={"mypy": 133},
         ),
         Project(
             location="https://github.com/pycqa/flake8",
@@ -1026,7 +1023,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src", "tests"],
             deps=["pytest"],
-            cost={"mypy": 13},
+            cost={"mypy": 22},
         ),
         Project(
             location="https://github.com/home-assistant/core",
@@ -1046,14 +1043,14 @@ def get_projects() -> list[Project]:
                 "types-backports",
             ],
             needs_mypy_plugins=True,
-            cost={"mypy": 3, "pyright": 240},
+            cost={"mypy": 411, "pyright": 240},
         ),
         Project(
             location="https://github.com/kornia/kornia",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["kornia"],
-            cost={"mypy": 21},
+            cost={"mypy": 31},
         ),
         Project(
             location="https://github.com/ibis-project/ibis",
@@ -1071,7 +1068,7 @@ def get_projects() -> list[Project]:
                 "types-requests",
                 "types-setuptools",
             ],
-            cost={"mypy": 77, "pyright": 60},
+            cost={"mypy": 101, "pyright": 60},
         ),
         Project(
             location="https://github.com/streamlit/streamlit",
@@ -1092,7 +1089,7 @@ def get_projects() -> list[Project]:
                 "click",
                 "pytest",
             ],
-            cost={"mypy": 37, "pyright": 50},
+            cost={"mypy": 0, "pyright": 50},
         ),
         Project(
             location="https://github.com/dragonchain/dragonchain",
@@ -1100,7 +1097,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["dragonchain"],
             deps=["types-redis", "types-requests"],
-            cost={"mypy": 16},
+            cost={"mypy": 26},
         ),
         Project(
             location="https://github.com/mikeshardmind/SinbadCogs",
@@ -1108,7 +1105,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             deps=["attrs", "types-pytz", "types-python-dateutil", "types-PyYAML"],
-            cost={"mypy": 9},
+            cost={"mypy": 14},
         ),
         Project(
             location="https://github.com/rotki/rotki",
@@ -1116,7 +1113,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["rotkehlchen", "tools/data_faker"],
             deps=["eth-typing", "types-requests", "types-setuptools"],
-            cost={"pyright": 60, "mypy": 11},
+            cost={"pyright": 60, "mypy": 9},
         ),
         Project(
             location="https://github.com/arviz-devs/arviz",
@@ -1124,7 +1121,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             deps=["numpy", "pytest", "scipy-stubs", "types-setuptools", "types-ujson", "xarray"],
-            cost={"pyright": 45, "mypy": 71},
+            cost={"pyright": 45, "mypy": 78},
         ),
         Project(
             location="https://github.com/urllib3/urllib3",
@@ -1140,7 +1137,7 @@ def get_projects() -> list[Project]:
                 "types-backports",
                 "types-requests",
             ],
-            cost={"mypy": 21},
+            cost={"mypy": 35},
         ),
         Project(
             location="https://github.com/common-workflow-language/schema_salad",
@@ -1148,7 +1145,7 @@ def get_projects() -> list[Project]:
             pyright_cmd=None,
             install_cmd="{install} $(grep -v mypy mypy-requirements.txt) -r requirements.txt",
             expected_success=("mypy",),
-            cost={"mypy": 23},
+            cost={"mypy": 33},
             supported_platforms=["linux", "darwin"],
         ),
         Project(
@@ -1157,7 +1154,7 @@ def get_projects() -> list[Project]:
             pyright_cmd=None,
             install_cmd="{install} $(grep -v mypy mypy-requirements.txt) -r requirements.txt",
             expected_success=("mypy",),
-            cost={"mypy": 71},
+            cost={"mypy": 99},
             supported_platforms=["linux", "darwin"],
         ),
         Project(
@@ -1166,7 +1163,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             deps=["attrs", "cattrs", "pytest", "aiohttp", "pathspec", "jinja2", "tomli"],
-            cost={"mypy": 21},
+            cost={"mypy": 32},
         ),
         Project(
             location="https://github.com/FasterSpeeding/Tanjun",
@@ -1174,14 +1171,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["tanjun"],
             deps=["hikari", "alluka"],
-            cost={"mypy": 29},
+            cost={"mypy": 46},
         ),
         Project(
             location="https://github.com/joerick/pyinstrument",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["pyinstrument"],
-            cost={"mypy": 8},
+            cost={"mypy": 13},
         ),
         Project(
             location="https://github.com/Gobot1234/steam.py",
@@ -1189,7 +1186,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["steam"],
             deps=["cryptography"],
-            cost={"mypy": 23},
+            cost={"mypy": 38},
         ),
         Project(
             location="https://github.com/cpitclaudel/alectryon",
@@ -1198,7 +1195,7 @@ def get_projects() -> list[Project]:
             paths=["alectryon.py"],
             deps=["types-docutils"],
             expected_success=("pyright",),
-            cost={"mypy": 8},
+            cost={"mypy": 14},
         ),
         Project(
             location="https://github.com/yurijmikhalevich/rclip",
@@ -1206,14 +1203,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["rclip"],
             deps=["numpy", "types-Pillow", "types-requests", "types-tqdm"],
-            cost={"mypy": 16},
+            cost={"mypy": 27},
         ),
         Project(
             location="https://github.com/psycopg/psycopg",
             mypy_cmd="{mypy}",
             pyright_cmd="{pyright}",
             deps=["pytest", "pproxy"],
-            cost={"mypy": 28},
+            cost={"mypy": 45},
         ),
         Project(
             location="https://gitlab.com/dkg/python-sop",
@@ -1221,7 +1218,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["sop"],
             expected_success=("pyright",),
-            cost={"mypy": 4},
+            cost={"mypy": 8},
         ),
         Project(
             location="https://github.com/Rapptz/discord.py",
@@ -1230,7 +1227,7 @@ def get_projects() -> list[Project]:
             paths=["discord"],
             deps=["types-requests", "types-setuptools", "aiohttp"],
             expected_success=("pyright",),
-            cost={"mypy": 77},
+            cost={"mypy": 63},
         ),
         Project(
             location="https://github.com/canonical/cloud-init",
@@ -1245,7 +1242,7 @@ def get_projects() -> list[Project]:
                 "types-requests",
                 "types-setuptools",
             ],
-            cost={"mypy": 47, "pyright": 50},
+            cost={"mypy": 72, "pyright": 50},
         ),
         Project(
             location="https://github.com/mongodb/mongo-python-driver",
@@ -1253,7 +1250,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["bson", "gridfs", "tools", "pymongo"],
             deps=["types-requests", "types-pyOpenSSL", "cryptography", "certifi"],
-            cost={"mypy": 23},
+            cost={"mypy": 36},
         ),
         Project(
             location="https://github.com/artigraph/artigraph",
@@ -1261,14 +1258,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["pydantic", "numpy", "pytest"],
             needs_mypy_plugins=True,
-            cost={"mypy": 27},
+            cost={"mypy": 44},
         ),
         Project(
             location="https://github.com/MaterializeInc/materialize",
             mypy_cmd="MYPYPATH=$MYPYPATH:misc/python {mypy} --explicit-package-bases misc/python",
             pyright_cmd="{pyright}",
             install_cmd="{install} -r ci/builder/requirements.txt",
-            cost={"mypy": 62},
+            cost={"mypy": 109},
         ),
         Project(
             location="https://github.com/canonical/operator",
@@ -1276,7 +1273,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["ops"],
             deps=["types-PyYAML"],
-            cost={"mypy": 11},
+            cost={"mypy": 18},
         ),
         Project(
             location="https://github.com/caronc/apprise",
@@ -1293,7 +1290,7 @@ def get_projects() -> list[Project]:
                 "certifi",
                 "babel",
             ],
-            cost={"mypy": 29},
+            cost={"mypy": 50},
         ),
         Project(
             location="https://github.com/Finistere/antidote",
@@ -1301,7 +1298,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             deps=["pytest"],
-            cost={"mypy": 20},
+            cost={"mypy": 31},
         ),
         Project(
             location="https://github.com/cognitedata/Expression",
@@ -1309,7 +1306,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             deps=["pytest"],
-            cost={"mypy": 15},
+            cost={"mypy": 25},
         ),
         Project(
             location="https://github.com/pyodide/pyodide",
@@ -1325,7 +1322,7 @@ def get_projects() -> list[Project]:
                 "pydantic",
             ],
             needs_mypy_plugins=True,
-            cost={"mypy": 19},
+            cost={"mypy": 26},
         ),
         Project(
             location="https://github.com/bokeh/bokeh",
@@ -1333,7 +1330,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src", "release"],
             deps=["types-boto", "tornado", "numpy", "jinja2", "selenium"],
-            cost={"pyright": 60, "mypy": 39},
+            cost={"pyright": 60, "mypy": 65},
         ),
         Project(
             location="https://github.com/pandas-dev/pandas-stubs",
@@ -1351,7 +1348,7 @@ def get_projects() -> list[Project]:
                 "SQLAlchemy",
             ],
             expected_success=("pyright",),
-            cost={"mypy": 161, "pyright": 75},
+            cost={"mypy": 189, "pyright": 75},
         ),
         Project(
             location="https://github.com/enthought/comtypes",
@@ -1359,7 +1356,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["comtypes"],
             deps=["numpy"],
-            cost={"mypy": 20},
+            cost={"mypy": 34},
         ),
         Project(
             location="https://github.com/mit-ll-responsible-ai/hydra-zen",
@@ -1367,7 +1364,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src", "tests/annotations"],
             deps=["pydantic", "beartype", "hydra-core"],
-            cost={"mypy": 36},
+            cost={"mypy": 70},
         ),
         Project(
             location="https://github.com/Toufool/AutoSplit",
@@ -1392,7 +1389,7 @@ def get_projects() -> list[Project]:
                 "types-requests",
                 "types-toml",
             ],
-            cost={"mypy": 53},
+            cost={"mypy": 51},
         ),
         Project(
             location="https://github.com/Avasam/speedrun.com_global_scoreboard_webapp",
@@ -1407,7 +1404,7 @@ def get_projects() -> list[Project]:
                 "types-httplib2",
                 "types-requests",
             ],
-            cost={"mypy": 22},
+            cost={"mypy": 35},
         ),
         Project(
             location="https://github.com/pwndbg/pwndbg",
@@ -1415,7 +1412,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["pwndbg"],
             deps=["types-gdb"],
-            cost={"mypy": 32, "pyright": 75},
+            cost={"mypy": 44, "pyright": 75},
         ),
         Project(
             location="https://github.com/keithasaurus/koda-validate",
@@ -1423,29 +1420,29 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["koda_validate"],
             deps=["koda"],
-            cost={"mypy": 11},
+            cost={"mypy": 18},
         ),
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/clinic/mypy.ini",
-            pyright_cmd=None,
             name_override="CPython (Argument Clinic)",
-            cost={"mypy": 7},
+            pyright_cmd=None,
+            cost={"mypy": 10},
         ),
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/cases_generator/mypy.ini",
-            pyright_cmd=None,
             name_override="CPython (cases_generator)",
-            cost={"mypy": 7},
+            pyright_cmd=None,
+            cost={"mypy": 10},
         ),
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/peg_generator/mypy.ini",
-            pyright_cmd=None,
             name_override="CPython (peg_generator)",
+            pyright_cmd=None,
             deps=["types-setuptools", "types-psutil"],
-            cost={"mypy": 7},
+            cost={"mypy": 10},
         ),
         Project(
             location="https://github.com/python-trio/trio",
@@ -1461,7 +1458,7 @@ def get_projects() -> list[Project]:
                 "pytest",
                 "sniffio",
             ],
-            cost={"mypy": 29},
+            cost={"mypy": 41},
         ),
         Project(
             location="https://github.com/pypa/setuptools",
@@ -1470,13 +1467,13 @@ def get_projects() -> list[Project]:
             paths=["setuptools", "pkg_resources"],
             deps=["pytest", "filelock", "ini2toml", "packaging", "tomli", "tomli-w"],
             expected_success=("pyright",),
-            cost={"mypy": 20},
+            cost={"mypy": 31},
         ),
         Project(
             location="https://github.com/detachhead/pytest-robotframework",
             mypy_cmd="{mypy} -p pytest_robotframework",
             pyright_cmd="{pyright}",
-            cost={"mypy": 5},
+            cost={"mypy": 4},
         ),
         Project(
             location="https://github.com/mhammond/pywin32",
@@ -1484,14 +1481,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             deps=["types-pywin32", "types-regex", "types-setuptools"],
-            cost={"mypy": 20},
+            cost={"mypy": 32},
         ),
         Project(
             location="https://github.com/beartype/beartype",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["beartype"],
-            cost={"mypy": 11},
+            cost={"mypy": 15},
         ),
         Project(
             location="https://github.com/colour-science/colour",
@@ -1499,7 +1496,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["colour"],
             deps=["matplotlib", "numpy", "pandas-stubs", "pytest", "scipy-stubs"],
-            cost={"mypy": 1500, "pyright": 180},
+            cost={"mypy": 464, "pyright": 180},
         ),
         Project(
             location="https://github.com/vega/altair",
@@ -1517,7 +1514,7 @@ def get_projects() -> list[Project]:
                 "scipy-stubs",
                 "types-jsonschema",
             ],
-            cost={"mypy": 94},
+            cost={"mypy": 124},
         ),
         Project(
             location="https://github.com/hydpy-dev/hydpy",
@@ -1525,7 +1522,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["hydpy"],
             deps=["numpy", "pandas-stubs", "scipy-stubs", "types-docutils", "types-networkx"],
-            cost={"mypy": 99},
+            cost={"mypy": 80},
         ),
         Project(
             location="https://github.com/static-frame/static-frame",
@@ -1533,7 +1530,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["static_frame"],
             deps=["numpy", "arraykit==0.10.0"],
-            cost={"mypy": 101},
+            cost={"mypy": 280},
         ),
         Project(
             location="https://github.com/mikeshardmind/async-utils",
@@ -1541,7 +1538,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
             expected_success=("pyright",),
-            cost={"mypy": 6},
+            cost={"mypy": 12},
         ),
         Project(
             location="https://github.com/pypa/cibuildwheel",
@@ -1557,14 +1554,14 @@ def get_projects() -> list[Project]:
                 "platformdirs",
                 "uv",
             ],
-            cost={"mypy": 10},
+            cost={"mypy": 17},
         ),
         Project(
             location="https://github.com/pypa/build",
             mypy_cmd="{mypy}",
             pyright_cmd="{pyright}",
             deps=["importlib_metadata", "packaging", "pyproject_hooks", "tomli", "uv"],
-            cost={"mypy": 7},
+            cost={"mypy": 11},
         ),
         Project(
             location="https://github.com/pypa/pyproject-metadata",
@@ -1573,7 +1570,7 @@ def get_projects() -> list[Project]:
             paths=["pyproject_metadata"],
             deps=["packaging"],
             expected_success=("pyright",),
-            cost={"mypy": 6},
+            cost={"mypy": 9},
         ),
         Project(
             location="https://github.com/strawberry-graphql/strawberry",
@@ -1581,7 +1578,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["strawberry"],
             deps=["graphql-core", "python-dateutil", "packaging"],
-            cost={"mypy": 17},
+            cost={"mypy": 25},
         ),
         Project(
             location="https://github.com/archlinux/archinstall",
@@ -1589,7 +1586,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             deps=["cryptography", "pydantic", "pytest"],
-            cost={"mypy": 24},
+            cost={"mypy": 34},
         ),
         Project(
             location="https://github.com/zopefoundation/zope.interface",
@@ -1597,6 +1594,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
             deps=["zope.testing"],
+            cost={"mypy": 15},
         ),
         Project(
             location="https://github.com/scikit-build/scikit-build-core",
@@ -1622,7 +1620,7 @@ def get_projects() -> list[Project]:
                 "tomli",
                 "types-setuptools",
             ],
-            cost={"mypy": 34},
+            cost={"mypy": 38},
         ),
         Project(
             location="https://github.com/hynek/svcs",
@@ -1631,6 +1629,7 @@ def get_projects() -> list[Project]:
             paths=["src", "tests/typing"],
             deps=["attrs", "flask", "aiohttp", "fastapi", "starlette"],
             expected_success=("mypy", "pyright"),
+            cost={"mypy": 57},
         ),
         Project(
             location="https://github.com/glyph/DateType",
@@ -1638,6 +1637,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
             expected_success=("mypy",),
+            cost={"mypy": 6},
         ),
     ]
     assert len(projects) == len({p.name for p in projects})


### PR DESCRIPTION
Now that type checking colour is much faster (https://github.com/python/mypy/issues/19403#issuecomment-3148623379), the current shard distribution is a bit lopsided. In a recent run in mypy's CI, the fastest shard finished in ~8min while the slowest took ~20min.

This updates the mypy costs using timings measured on GitHub Actions runners  ([run here](https://github.com/brianschubert/mypy/actions/runs/16737266720)). I used interpreted mypy for these timings, but I could re-measure for mypyc-compiled mypy if that's preferred.