### PR TITLE
Fix `install_cmd` command for cwltool

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1155,6 +1155,11 @@ def get_projects() -> list[Project]:
             location="https://github.com/common-workflow-language/cwltool",
             mypy_cmd="MYPYPATH=$MYPYPATH:mypy-stubs {mypy} cwltool tests/*.py setup.py",
             pyright_cmd=None,
+            # TODO: could this just be the following?
+            # It would install mypy into the environment which is weird but would probably be fine?
+            # https://github.com/hauntsaninja/mypy_primer/pull/195#discussion_r2282164031
+            #
+            # install_cmd="{install} -r mypy-requirements.txt -r requirements.txt",
             install_cmd="{install} $(grep -v -e 'mypy' -e ';' mypy-requirements.txt) -r requirements.txt",
             expected_success=("mypy",),
             cost={"mypy": 99},


### PR DESCRIPTION
Following changes upstream in https://github.com/common-workflow-language/cwltool/commit/284a14587b1f648a19c9eb01fba73908c9c44ac0, mypy_primer is failing to execute the `install_cmd` command for cwltool:

```
subprocess.CalledProcessError: Command 'uv pip install --python /tmp/mypy_primer/projects/_cwltool_venv/bin/python $(grep -v mypy mypy-requirements.txt) -r requirements.txt' returned non-zero exit status 2.
```

Example failing run over at ty: https://github.com/astral-sh/ruff/actions/runs/17038055598/job/48295068236?pr=19945

Executing `uv pip install $(grep -v mypy mypy-requirements.txt) -r requirements.txt` from a local clone of `cwltool`, the error being returned by uv is:

```
error: Failed to parse: `pydantic==2.12.0a1;`
  Caused by: Expected marker value, found end of dependency specification
pydantic==2.12.0a1;
                   ^
```

This PR is a quick fix that should get everything green again: the `grep` command is edited to just ignore all dependency lines in mypy-requirements.txt that contain semicolons