### PR TITLE
Add Egglog Project

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1647,6 +1647,15 @@ def get_projects() -> list[Project]:
             expected_success=("mypy",),
             cost={"mypy": 6},
         ),
+        Project(
+            location="https://github.com/egraphs-good/egglog-python",
+            mypy_cmd="{mypy} {paths}",
+            pyright_cmd="{pyright} {paths}",
+            paths=["python"],
+            deps=["anywidget", "syrupy"],
+            expected_success=("mypy",),
+            cost={"mypy": 6},
+        ),
     ]
     assert len(projects) == len({p.name for p in projects})
     for p in projects:


### PR DESCRIPTION
This adds support for the egglog-python project (https://github.com/egraphs-good/egglog-python) which is a library used to build DSLs in Python that can be optimized with e-graphs.

It uses type annotations heavily to help with compile time safety of the DSLs.

The one failing line that happens now seems to be from a change to MyPy that is unreleased.