### PR TITLE
remove `scipy-stubs` as `AutoSplit` dependency

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1386,7 +1386,6 @@ def get_projects() -> list[Project]:
                 "packaging",
                 "PyWinCtl",
                 "PySide6-Essentials",
-                "scipy-stubs",
                 "types-D3DShot",
                 "types-keyboard",
                 "types-Pillow",


### PR DESCRIPTION
The `scipy` and `scipy-stubs` deps of `AutoSplit` were recently removed: Toufool/AutoSplit#331