### PR TITLE
Add `django-test-migrations` which uses `django-stubs` with a plugin

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -314,6 +314,16 @@ def get_projects() -> list[Project]:
             cost={"pyright": 60, "mypy": 173},
         ),
         Project(
+            location="https://github.com/wemake-services/django-test-migrations",
+            mypy_cmd="{mypy} {paths}",
+            pyright_cmd=None,
+            paths=["django_test_migrations"],
+            deps=["django-stubs"],
+            needs_mypy_plugins=True,  # we want to test `django-stubs` plugin
+            expected_success=("mypy",),
+            cost={"mypy": 6},
+        ),
+        Project(
             location="https://github.com/dropbox/stone",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",


### PR DESCRIPTION
Link: https://github.com/wemake-services/django-test-migrations

I want to add more packages that actually use `django-stubs` with the plugin, so it would be helpful for us during PRs :)

Refs https://github.com/typeddjango/django-stubs/issues/1362