### PR TITLE
Add flag to install `mypyc/lib-rt` alongside mypy

### DIFF
--- a/mypy_primer/globals.py
+++ b/mypy_primer/globals.py
@@ -17,6 +17,7 @@ class _Args:
     repo: str | None
     type_checker: str
     mypyc_compile_level: int | None
+    mypy_install_librt: bool
 
     custom_typeshed_repo: str
     new_typeshed: str | None
@@ -96,6 +97,12 @@ def parse_options(argv: list[str]) -> _Args:
         default=None,
         type=int,
         help="Compile mypy with the given mypyc optimisation level",
+    )
+    type_checker_group.add_argument(
+        "--mypy-install-librt",
+        action="store_true",
+        help="(Experimental) Whether to install the mypyc C runtime library "
+        "(mypyc/lib-rt) when using mypy as the type checker",
     )
 
     type_checker_group.add_argument(

--- a/mypy_primer/main.py
+++ b/mypy_primer/main.py
@@ -42,7 +42,11 @@ def setup_type_checker(
 
     if ARGS.type_checker == "mypy":
         setup_fn = setup_mypy
-        kwargs = {"repo": ARGS.repo, "mypyc_compile_level": ARGS.mypyc_compile_level}
+        kwargs = {
+            "repo": ARGS.repo,
+            "mypyc_compile_level": ARGS.mypyc_compile_level,
+            "install_librt": ARGS.mypy_install_librt,
+        }
     elif ARGS.type_checker == "pyright":
         setup_fn = setup_pyright
         kwargs = {"repo": ARGS.repo}
@@ -273,6 +277,7 @@ async def bisect(ARGS: _Args) -> None:
             repo=ARGS.repo,
             mypyc_compile_level=ARGS.mypyc_compile_level,
             editable=True,  # important
+            install_librt=ARGS.mypy_install_librt,
         )
         repo_dir = ARGS.base_dir / "bisect_mypy" / "mypy"
     elif ARGS.type_checker == "pyright":

--- a/mypy_primer/type_checker.py
+++ b/mypy_primer/type_checker.py
@@ -17,6 +17,7 @@ async def setup_mypy(
     repo: str | None,
     mypyc_compile_level: int | None,
     editable: bool = False,
+    install_librt: bool = False,
 ) -> Path:
     mypy_dir.mkdir(exist_ok=True)
     venv = Venv(mypy_dir / "venv")
@@ -35,6 +36,7 @@ async def setup_mypy(
     if isinstance(revision_like, str) and not editable and repo is None:
         # optimistically attempt to install the revision of mypy we want from pypi
         try:
+            # TOOD: support installing lib-rt?
             await pip_install(f"mypy=={revision_like}")
             install_from_repo = False
         except subprocess.CalledProcessError:
@@ -77,6 +79,19 @@ async def setup_mypy(
             targets.append("tomli")
             targets.append("pathspec")
             await pip_install(*targets)
+
+        if install_librt:
+            try:
+                await run(
+                    [str(venv.python), "-m", "pip", "install", "./mypyc/lib-rt"],
+                    cwd=repo_dir,
+                    output=True,
+                )
+            except subprocess.CalledProcessError as e:
+                print("Error while building lib-rt", file=sys.stderr)
+                print(e.stdout, file=sys.stderr)
+                print(e.stderr, file=sys.stderr)
+                raise e
 
     with open(venv.site_packages / "primer_plugin.pth", "w") as f:
         # pth file that lets us let mypy import plugins from another venv


### PR DESCRIPTION
c.f. https://github.com/python/mypy/issues/19844#issuecomment-3288922936

I put this behind a flag to avoid affecting other projects running mypy_primer that may not be prepared to compile an extension module in their CI