### PR TITLE
Temporarily drop `materialize` from projects

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1275,13 +1275,13 @@ def get_projects() -> list[Project]:
             needs_mypy_plugins=True,
             cost={"mypy": 44},
         ),
-        Project(
-            location="https://github.com/MaterializeInc/materialize",
-            mypy_cmd="MYPYPATH=$MYPYPATH:misc/python {mypy} --explicit-package-bases misc/python",
-            pyright_cmd="{pyright}",
-            install_cmd="{install} -r ci/builder/requirements.txt",
-            cost={"mypy": 109},
-        ),
+        # Project(
+        #     location="https://github.com/MaterializeInc/materialize",
+        #     mypy_cmd="MYPYPATH=$MYPYPATH:misc/python {mypy} --explicit-package-bases misc/python",
+        #     pyright_cmd="{pyright}",
+        #     install_cmd="{install} -r ci/builder/requirements.txt",
+        #     cost={"mypy": 109},
+        # ),
         Project(
             location="https://github.com/canonical/operator",
             mypy_cmd="{mypy} {paths}",

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1275,6 +1275,8 @@ def get_projects() -> list[Project]:
             needs_mypy_plugins=True,
             cost={"mypy": 44},
         ),
+        # Disabled for now due to unavailable VCS dependency causing setup failures.
+        # See typeshed#14720.
         # Project(
         #     location="https://github.com/MaterializeInc/materialize",
         #     mypy_cmd="MYPYPATH=$MYPYPATH:misc/python {mypy} --explicit-package-bases misc/python",


### PR DESCRIPTION
See https://github.com/python/typeshed/pull/14720, https://github.com/python/typeshed/pull/14716#issuecomment-3289636151

`materialize` has VCS dependency on a GitHub repo that was recently deleted or made private. This is causing the venv setup to fail, and is resulting in mypy_primer hanging in various projects' CI.
