### PR TITLE
Revert "Temporarily drop `materialize` from projects"

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1275,15 +1275,13 @@ def get_projects() -> list[Project]:
             needs_mypy_plugins=True,
             cost={"mypy": 44},
         ),
-        # Disabled for now due to unavailable VCS dependency causing setup failures.
-        # See typeshed#14720.
-        # Project(
-        #     location="https://github.com/MaterializeInc/materialize",
-        #     mypy_cmd="MYPYPATH=$MYPYPATH:misc/python {mypy} --explicit-package-bases misc/python",
-        #     pyright_cmd="{pyright}",
-        #     install_cmd="{install} -r ci/builder/requirements.txt",
-        #     cost={"mypy": 109},
-        # ),
+        Project(
+            location="https://github.com/MaterializeInc/materialize",
+            mypy_cmd="MYPYPATH=$MYPYPATH:misc/python {mypy} --explicit-package-bases misc/python",
+            pyright_cmd="{pyright}",
+            install_cmd="{install} -r ci/builder/requirements.txt",
+            cost={"mypy": 109},
+        ),
         Project(
             location="https://github.com/canonical/operator",
             mypy_cmd="{mypy} {paths}",


### PR DESCRIPTION
Reverts hauntsaninja/mypy_primer#206

The unavailable VCS dependency has been fixed in `materialize`'s main branch (https://github.com/MaterializeInc/materialize/commit/fe0e554cdc5b2fe3b9d8fa67b133c088a4952c4a), so this should be safe to re-add