### PR TITLE
Use `--summary=none` instead of `--no-summary` in pyrefly command.

### DIFF
--- a/mypy_primer/model.py
+++ b/mypy_primer/model.py
@@ -351,7 +351,7 @@ class Project:
 
         pyrefly_cmd = pyrefly_cmd.format_map(_FormatMap(pyrefly=pyrefly, paths=self.paths))
 
-        pyrefly_cmd += f" --python-interpreter {quote_path(self.venv.dir)}/bin/python --no-summary --output-format min-text"
+        pyrefly_cmd += f" --python-interpreter {quote_path(self.venv.dir)}/bin/python --summary=none --output-format min-text"
         return pyrefly_cmd
 
     async def run_pyrefly(


### PR DESCRIPTION
We'd like to remove the `--no-summary` flag from Pyrefly in favor of `--summary=none` (https://github.com/facebook/pyrefly/issues/730).