### PR TITLE
Fix CPython project configs for ty and pyrefly

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1439,6 +1439,8 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/clinic/mypy.ini",
+            ty_cmd="{ty} check --project='Tools/clinic'",
+            paths=["Tools/clinic"],
             name_override="CPython (Argument Clinic)",
             pyright_cmd=None,
             cost={"mypy": 10},
@@ -1446,6 +1448,8 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/cases_generator/mypy.ini",
+            ty_cmd="{ty} check --project='Tools/cases_generator'",
+            paths=["Tools/cases_generator"],
             name_override="CPython (cases_generator)",
             pyright_cmd=None,
             cost={"mypy": 10},
@@ -1453,6 +1457,8 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/python/cpython",
             mypy_cmd="{mypy} --config-file Tools/peg_generator/mypy.ini",
+            ty_cmd="{ty} check --project='Tools/peg_generator'",
+            paths=["Tools/peg_generator"],
             name_override="CPython (peg_generator)",
             pyright_cmd=None,
             deps=["types-setuptools", "types-psutil"],


### PR DESCRIPTION
I noticed that ty was type-checking the whole of the CPython repo for each of these projects during our mypy_primer runs. The intent is that a type checker should only check the type-annotated, mypy-checked subdirectories in CPython that are self-contained, isolated projects. The mypy config for these projects achieves this because the files mypy should check are detailed in the `Tools/{clinic,peg_generator,cases_generator}/mypy.ini` files, but the configs for the other type checkers aren't currently sufficient.

For pyrefly, it seems like it's sufficient to just set `paths`, and pyrefly is able to infer what the first-party search path should be from that. For ty, we currently need to either use `--project=Tools/clinic` or `--config='environment.root = ["Tools/clinic"]'`. I think either would work fine here, but `--project` is a bit simpler.

I tested running `uvx ty check --project=Tools/clinic` from the CPython repo root and the results seemed pretty reasonable! I also did similarly for pyrefly and for the other CPython projects included in primer.