### PR TITLE
add `numpy-stl`

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1672,6 +1672,15 @@ def get_projects() -> list[Project]:
             expected_success=("mypy",),
             cost={"mypy": 6},
         ),
+        Project(
+            location="https://github.com/WoLpH/numpy-stl",
+            mypy_cmd="{mypy} {paths}",
+            pyright_cmd="{pyright} {paths}",
+            pyrefly_cmd="{pyrefly}",
+            paths=["stl"],
+            deps=["numpy", "python-utils"],
+            expected_success=("mypy", "pyright", "pyrefly"),
+        ),
     ]
     assert len(projects) == len({p.name for p in projects})
     for p in projects:


### PR DESCRIPTION
https://github.com/wolph/numpy-stl

It's a pretty popular project, and passes mypy (strict), (based)pyright (strict), and pyrefly ([config](https://github.com/wolph/numpy-stl/blob/develop/pyproject.toml), [workflow](https://github.com/wolph/numpy-stl/blob/develop/.github/workflows/type_check.yml)), so I figured it'd make for a nice addition :)