### PR TITLE
add pyrefly command to `scipy-stubs`

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -985,7 +985,7 @@ def get_projects() -> list[Project]:
             location="https://github.com/scipy/scipy-stubs",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
-            pyrefly_cmd="{pyrefly} {paths}",
+            pyrefly_cmd="{pyrefly} check {paths}",
             paths=["."],
             deps=[
                 "array-api-compat",


### PR DESCRIPTION
I didn't see any other projects with pyrefly support yet, so is it ok like this?