### PR TITLE
Update arraykit to 1.2.0

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1553,7 +1553,7 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["static_frame"],
-            deps=["numpy", "arraykit==0.10.0"],
+            deps=["numpy", "arraykit==1.2.0"],
             cost={"mypy": 280},
         ),
         Project(


### PR DESCRIPTION
Added support for Python 3.14. Required for https://github.com/python/mypy/pull/20355

`static-frame` master does pin `1.2.0` as well already.
https://github.com/static-frame/static-frame/blob/master/requirements-test-3_14.txt

https://github.com/static-frame/arraykit