### PR TITLE
Tweak the pyrefly_cmd in numpy-stl

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1688,7 +1688,7 @@ def get_projects() -> list[Project]:
             location="https://github.com/WoLpH/numpy-stl",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
-            pyrefly_cmd="{pyrefly}",
+            pyrefly_cmd="{pyrefly} check {paths}",
             paths=["stl"],
             deps=["numpy", "python-utils"],
             expected_success=("mypy", "pyright", "pyrefly"),


### PR DESCRIPTION
On trunk this crashes because `pyrefly` by itself doesn't run check, we need `pyrefly check <paths> <options>`.

See [here](https://github.com/facebook/pyrefly/actions/runs/20875257569/job/59983486878?fbclid=IwY2xjawPPaIlleHRuA2FlbQIxMQBicmlkETFYZ0kycnBVakE5MUV0YUhUc3J0YwZhcHBfaWQBMAABHoo7a3O-90jEccvgXUQnWjxzu0L2uhUTwwh95incPkGpqzyvgTzwxiGC9jAK_aem_FVCWhas1APsJ5s4z5eIC2A) for an example failed run.

Testing the fix:
```
> mypy_primer -k numpy-stl --type-checker pyrefly --debug
git fetch        in /tmp/mypy_primer/pyrefly_new/pyrefly
git fetch        in /tmp/mypy_primer/pyrefly_old/pyrefly
git clean -ffxd  in /tmp/mypy_primer/pyrefly_new/pyrefly
git clean -ffxd  in /tmp/mypy_primer/pyrefly_old/pyrefly
git reset --hard origin/HEAD --recurse-submodules        in /tmp/mypy_primer/pyrefly_new/pyrefly
git reset --hard origin/HEAD --recurse-submodules        in /tmp/mypy_primer/pyrefly_old/pyrefly
git rev-list --tags -1   in /tmp/mypy_primer/pyrefly_old/pyrefly
git describe --tags 65be741335fee265e9d2ed8e2a3d40bb5a6e391e     in /tmp/mypy_primer/pyrefly_old/pyrefly
git checkout --force --recurse-submodules origin/HEAD    in /tmp/mypy_primer/pyrefly_old/pyrefly
git branch -D 0.47.0     in /tmp/mypy_primer/pyrefly_old/pyrefly
git checkout --force --recurse-submodules 0.47.0         in /tmp/mypy_primer/pyrefly_old/pyrefly
cargo build --profile release    in /tmp/mypy_primer/pyrefly_old/pyrefly/pyrefly
cargo build --profile release    in /tmp/mypy_primer/pyrefly_new/pyrefly/pyrefly
/tmp/mypy_primer/pyrefly_new/target/release/pyrefly --version
/tmp/mypy_primer/pyrefly_old/target/release/pyrefly --version
new pyrefly version: pyrefly 0.47.0
old pyrefly version: pyrefly 0.47.0
git clone --recurse-submodules https://github.com/WoLpH/numpy-stl /tmp/mypy_primer/projects/numpy-stl --depth 1  in /tmp/mypy_primer/projects
uv venv /tmp/mypy_primer/projects/_numpy-stl_venv --python /Users/stroxler/kode/mypy_primer/.venv/bin/python3 --seed
uv pip install --python /tmp/mypy_primer/projects/_numpy-stl_venv/bin/python numpy python-utils  in /tmp/mypy_primer/projects/numpy-stl
/tmp/mypy_primer/pyrefly_new/target/release/pyrefly check stl --python-interpreter-path /tmp/mypy_primer/projects/_numpy-stl_venv/bin/python --summary=none --output-format min-text     in /tmp/mypy_primer/projects/numpy-stl
/tmp/mypy_primer/pyrefly_old/target/release/pyrefly check stl --python-interpreter-path /tmp/mypy_primer/projects/_numpy-stl_venv/bin/python --summary=none --output-format min-text     in /tmp/mypy_primer/projects/numpy-stl
/tmp/mypy_primer/pyrefly_old/target/release/pyrefly on numpy-stl took 0.90s
/tmp/mypy_primer/pyrefly_new/target/release/pyrefly on numpy-stl took 0.90s

numpy-stl
https://github.com/WoLpH/numpy-stl
----------

old
> /tmp/mypy_primer/pyrefly_old/target/release/pyrefly check stl --python-interpreter-path /tmp/mypy_primer/projects/_numpy-stl_venv/bin/python --summary=none --output-format min-text (0.9s)
         WARN stl/base.py:596:13-33: `numpy.ndarray.shape` is deprecated [deprecated]
----------

new
> /tmp/mypy_primer/pyrefly_new/target/release/pyrefly check stl --python-interpreter-path /tmp/mypy_primer/projects/_numpy-stl_venv/bin/python --summary=none --output-format min-text (0.9s)
         WARN stl/base.py:596:13-33: `numpy.ndarray.shape` is deprecated [deprecated]
==========
```