### PR TITLE
Remove `pkg_resources` from setuptools `paths`

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1503,7 +1503,7 @@ def get_projects() -> list[Project]:
             location="https://github.com/pypa/setuptools",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
-            paths=["setuptools", "pkg_resources"],
+            paths=["setuptools"],
             deps=["pytest", "filelock", "ini2toml", "packaging", "tomli", "tomli-w"],
             expected_success=("pyright",),
             cost={"mypy": 31},


### PR DESCRIPTION
## Summary

I believe `pkg_resources` was removed back in [May](https://github.com/pypa/setuptools/commit/8ba2f38), but that change just merged into the default branch [today](https://github.com/pypa/setuptools/commit/530d114).
