### PR TITLE
Add viur-framework/viur-toolkit to projects

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1723,6 +1723,7 @@ def get_projects() -> list[Project]:
         Project(
             location="https://github.com/viur-framework/viur-toolkit",
             mypy_cmd="{mypy} {paths}",
+            pyright_cmd="{pyright} {paths}",
             paths=["src"],
             deps=["viur-core"],
             expected_success=("mypy",),

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -1720,6 +1720,13 @@ def get_projects() -> list[Project]:
             paths=["src/cryptography", "tests"],
             deps=["cffi", "typing-extensions", "pytest"],
         ),
+        Project(
+            location="https://github.com/viur-framework/viur-toolkit",
+            mypy_cmd="{mypy} {paths}",
+            paths=["src"],
+            deps=["viur-core"],
+            expected_success=("mypy",),
+        ),
     ]
     assert len(projects) == len({p.name for p in projects})
     for p in projects:


### PR DESCRIPTION
Adds `viur-framework/viur-toolkit` as suggested in #42 by @hauntsaninja.

The project uses strict mypy settings (`disallow_untyped_defs`, `warn_redundant_casts`, `warn_unused_ignores`) which makes it a useful signal for mypy regressions.

Refs #42