### PR TITLE
Disable parallel checking for mypy project

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -66,7 +66,7 @@ def get_projects() -> list[Project]:
     projects = [
         Project(
             location="https://github.com/python/mypy",
-            mypy_cmd="{mypy} --config-file mypy_self_check.ini -p mypy -p mypyc",
+            mypy_cmd="{mypy} --config-file mypy_self_check.ini --num-workers=0 -p mypy -p mypyc",
             pyright_cmd="{pyright} {paths}",
             paths=["mypy", "mypyc"],
             deps=["pytest", "types-psutil", "types-setuptools", "filelock", "tomli"],


### PR DESCRIPTION
Since python/mypy#21221, `mypy_self_check.ini` sets `num_workers = 4`. This is causing mypy_primer to fail when checking mypy, since mypy_primer disables the cache directory but parallel checking requires the cache directory to be enabled.

This has been causing hard crashes in typeshed's CI (see e.g. https://github.com/python/typeshed/pull/15653) as well as silent failures in mypy's CI (since the current error isn't picked up by the diff analysis).


```shell
$ uv run python3 -m mypy_primer --new master --old master -k 'mypy$'

mypy
https://github.com/python/mypy
----------

old
> /tmp/mypy_primer/mypy_old/venv/bin/mypy --config-file mypy_self_check.ini -p mypy -p mypyc --python-executable=/tmp/mypy_primer/projects/_mypy_venv/bin/python --warn-unused-ignores --warn-redundant-casts --no-incremental --cache-dir=/dev/null --show-traceback --soft-error-limit=-1 (0.5s)
UNEXPECTED FAILURE
        error: cache must be enabled in parallel mode
----------

new
> /tmp/mypy_primer/mypy_new/venv/bin/mypy --config-file mypy_self_check.ini -p mypy -p mypyc --python-executable=/tmp/mypy_primer/projects/_mypy_venv/bin/python --warn-unused-ignores --warn-redundant-casts --no-incremental --cache-dir=/dev/null --show-traceback --soft-error-limit=-1 (0.5s)
UNEXPECTED FAILURE
        error: cache must be enabled in parallel mode
```

