### PR TITLE
Add costs for ty

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -71,7 +71,7 @@ def get_projects() -> list[Project]:
             paths=["mypy", "mypyc"],
             deps=["pytest", "types-psutil", "types-setuptools", "filelock", "tomli"],
             expected_success=("mypy",),
-            cost={"mypy": 82, "pyright": 50},
+            cost={"mypy": 82, "pyright": 50, "ty": 10},
         ),
         Project(
             location="https://github.com/hauntsaninja/mypy_primer",
@@ -79,7 +79,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 12},
+            cost={"mypy": 12, "ty": 1},
         ),
         Project(
             location="https://github.com/psf/black",
@@ -88,7 +88,7 @@ def get_projects() -> list[Project]:
             paths=["src"],
             deps=["aiohttp", "click", "pathspec", "tomli", "platformdirs", "packaging"],
             expected_success=("mypy",),
-            cost={"mypy": 31},
+            cost={"mypy": 31, "ty": 1},
         ),
         Project(
             location="https://github.com/hauntsaninja/pyp",
@@ -96,7 +96,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             expected_success=("mypy",),
-            cost={"mypy": 8},
+            cost={"mypy": 8, "ty": 1},
         ),
         Project(
             location="https://github.com/pytest-dev/pytest",
@@ -105,7 +105,7 @@ def get_projects() -> list[Project]:
             paths=["src", "testing"],
             deps=["attrs", "pluggy", "py", "types-setuptools"],
             expected_success=("mypy",),
-            cost={"mypy": 47},
+            cost={"mypy": 47, "ty": 3},
         ),
         Project(
             location="https://github.com/pandas-dev/pandas",
@@ -121,7 +121,7 @@ def get_projects() -> list[Project]:
                 "pytest",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 355},
+            cost={"mypy": 355, "ty": 14},
         ),
         Project(
             location="https://github.com/pycqa/pylint",
@@ -130,7 +130,7 @@ def get_projects() -> list[Project]:
             paths=["pylint/checkers"],
             deps=["types-toml"],
             expected_success=("mypy",),
-            cost={"mypy": 35},
+            cost={"mypy": 35, "ty": 1},
         ),
         Project(
             location="https://github.com/aio-libs/aiohttp",
@@ -140,7 +140,7 @@ def get_projects() -> list[Project]:
             install_cmd="AIOHTTP_NO_EXTENSIONS=1 {install} -e .",
             deps=["pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 34},
+            cost={"mypy": 34, "ty": 3},
             supported_platforms=["linux", "darwin"],
         ),
         Project(
@@ -148,7 +148,7 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} src/attrs/__init__.pyi src/attr/__init__.pyi src/attr/_typing_compat.pyi src/attr/_version_info.pyi src/attr/converters.pyi src/attr/exceptions.pyi src/attr/filters.pyi src/attr/setters.pyi src/attr/validators.pyi typing-examples",
             pyright_cmd="{pyright}",
             expected_success=("mypy",),
-            cost={"mypy": 9},
+            cost={"mypy": 9, "ty": 1},
         ),
         Project(
             location="https://github.com/sphinx-doc/sphinx",
@@ -156,7 +156,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["sphinx"],
             deps=["babel", "docutils-stubs", "types-requests", "packaging", "jinja2"],
-            cost={"mypy": 125},
+            cost={"mypy": 125, "ty": 3},
         ),
         Project(
             location="https://github.com/scikit-learn/scikit-learn",
@@ -165,7 +165,7 @@ def get_projects() -> list[Project]:
             paths=["sklearn"],
             deps=["joblib", "numpy", "scipy-stubs", "threadpoolctl"],
             expected_success=("mypy",),
-            cost={"mypy": 138, "pyright": 240},
+            cost={"mypy": 138, "pyright": 240, "ty": 16},
         ),
         Project(
             location="https://github.com/pypa/bandersnatch",
@@ -174,7 +174,7 @@ def get_projects() -> list[Project]:
             paths=["src"],
             deps=["types-filelock", "types-freezegun", "types-setuptools"],
             expected_success=("mypy",),
-            cost={"mypy": 18},
+            cost={"mypy": 18, "ty": 1},
         ),
         Project(
             location="https://github.com/hauntsaninja/boostedblob",
@@ -183,7 +183,7 @@ def get_projects() -> list[Project]:
             paths=["boostedblob"],
             deps=["aiohttp", "uvloop", "pycryptodome"],
             expected_success=("mypy",),
-            cost={"mypy": 24},
+            cost={"mypy": 24, "ty": 1},
             supported_platforms=["linux", "darwin"],
         ),
         Project(
@@ -193,7 +193,7 @@ def get_projects() -> list[Project]:
             paths=["asynq"],
             deps=["qcore", "pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 19},
+            cost={"mypy": 19, "ty": 1},
         ),
         Project(
             location="https://github.com/scrapy/scrapy",
@@ -202,7 +202,7 @@ def get_projects() -> list[Project]:
             paths=["."],
             deps=["attrs", "types-pyOpenSSL", "types-setuptools"],
             expected_success=("mypy",),
-            cost={"mypy": 36},
+            cost={"mypy": 36, "ty": 3},
         ),
         Project(
             location="https://github.com/pypa/twine",
@@ -211,7 +211,7 @@ def get_projects() -> list[Project]:
             paths=["twine"],
             deps=["keyring", "types-requests", "rich", "packaging"],
             expected_success=("mypy",),
-            cost={"mypy": 21},
+            cost={"mypy": 21, "ty": 1},
         ),
         Project(
             location="https://github.com/more-itertools/more-itertools",
@@ -219,7 +219,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["more_itertools"],
             expected_success=("mypy",),
-            cost={"mypy": 8},
+            cost={"mypy": 8, "ty": 1},
         ),
         Project(
             location="https://github.com/pydata/xarray",
@@ -246,7 +246,7 @@ def get_projects() -> list[Project]:
                 "types-setuptools",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 223, "pyright": 170},
+            cost={"mypy": 223, "pyright": 170, "ty": 6},
         ),
         Project(
             location="https://github.com/pallets/werkzeug",
@@ -255,7 +255,7 @@ def get_projects() -> list[Project]:
             paths=["src/werkzeug", "tests"],
             deps=["types-setuptools", "pytest", "markupsafe"],
             expected_success=("mypy",),
-            cost={"mypy": 32},
+            cost={"mypy": 32, "ty": 1},
         ),
         Project(
             location="https://github.com/pallets/jinja",
@@ -263,7 +263,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["markupsafe"],
             expected_success=("mypy",),
-            cost={"mypy": 16},
+            cost={"mypy": 16, "ty": 1},
         ),
         Project(
             location="https://github.com/mystor/git-revise",
@@ -271,7 +271,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["gitrevise"],
             expected_success=("mypy",),
-            cost={"mypy": 7},
+            cost={"mypy": 7, "ty": 1},
         ),
         Project(
             location="https://github.com/PyGithub/PyGithub",
@@ -288,7 +288,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src/pegen"],
             expected_success=("mypy",),
-            cost={"mypy": 8},
+            cost={"mypy": 8, "ty": 1},
         ),
         Project(
             location="https://github.com/zulip/zulip",
@@ -311,7 +311,7 @@ def get_projects() -> list[Project]:
             # figure out what it would take to make it actually work
             # needs_mypy_plugins=True,
             expected_success=("mypy",),
-            cost={"pyright": 60, "mypy": 173},
+            cost={"pyright": 60, "mypy": 173, "ty": 10},
         ),
         Project(
             location="https://github.com/wemake-services/django-test-migrations",
@@ -321,7 +321,7 @@ def get_projects() -> list[Project]:
             deps=["django-stubs"],
             needs_mypy_plugins=True,  # we want to test `django-stubs` plugin
             expected_success=("mypy",),
-            cost={"mypy": 6},
+            cost={"mypy": 6, "ty": 1},
         ),
         Project(
             location="https://github.com/wemake-services/django-modern-rest",
@@ -346,7 +346,7 @@ def get_projects() -> list[Project]:
             paths=["stone", "test"],
             deps=["types-six"],
             expected_success=("mypy",),
-            cost={"mypy": 18},
+            cost={"mypy": 18, "ty": 1},
         ),
         Project(
             location="https://github.com/yelp/paasta",
@@ -365,7 +365,7 @@ def get_projects() -> list[Project]:
                 "types-tzlocal",
                 "types-ujson",
             ],
-            cost={"mypy": 31},
+            cost={"mypy": 31, "ty": 2},
             supported_platforms=["linux", "darwin"],
         ),
         Project(
@@ -387,7 +387,7 @@ def get_projects() -> list[Project]:
                 "pydantic",
             ],
             needs_mypy_plugins=True,
-            cost={"mypy": 56, "pyright": 60},
+            cost={"mypy": 56, "pyright": 60, "ty": 7},
         ),
         Project(
             location="https://github.com/pallets/itsdangerous",
@@ -396,7 +396,7 @@ def get_projects() -> list[Project]:
             paths=["src/itsdangerous"],
             deps=["pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 7},
+            cost={"mypy": 7, "ty": 1},
         ),
         Project(
             location="https://github.com/jab/bidict",
@@ -404,7 +404,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["bidict"],
             expected_success=("mypy",),
-            cost={"mypy": 7},
+            cost={"mypy": 7, "ty": 1},
         ),
         Project(
             location="https://github.com/jaraco/zipp",
@@ -412,7 +412,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["zipp"],
             expected_success=("mypy",),
-            cost={"mypy": 7},
+            cost={"mypy": 7, "ty": 1},
         ),
         Project(
             location="https://github.com/aaugustin/websockets",
@@ -421,7 +421,7 @@ def get_projects() -> list[Project]:
             paths=["src"],
             deps=["werkzeug"],
             expected_success=("mypy",),
-            cost={"mypy": 21},
+            cost={"mypy": 21, "ty": 1},
         ),
         Project(
             location="https://github.com/pycqa/isort",
@@ -430,14 +430,14 @@ def get_projects() -> list[Project]:
             paths=["isort"],
             deps=["types-setuptools"],
             expected_success=("mypy",),
-            cost={"mypy": 15},
+            cost={"mypy": 15, "ty": 6},
         ),
         Project(
             location="https://github.com/aio-libs/aioredis",
             mypy_cmd="{mypy} {paths} --ignore-missing-imports",
             pyright_cmd="{pyright} {paths}",
             paths=["aioredis"],
-            cost={"mypy": 14},
+            cost={"mypy": 14, "ty": 1},
         ),
         Project(
             location="https://github.com/agronholm/anyio",
@@ -445,7 +445,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
             expected_success=("mypy",),
-            cost={"mypy": 29},
+            cost={"mypy": 29, "ty": 1},
         ),
         Project(
             location="https://github.com/aio-libs/yarl",
@@ -454,7 +454,7 @@ def get_projects() -> list[Project]:
             paths=["yarl", "tests"],
             deps=["multidict", "pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 25},
+            cost={"mypy": 25, "ty": 1},
         ),
         Project(
             location="https://github.com/freqtrade/freqtrade",
@@ -474,7 +474,7 @@ def get_projects() -> list[Project]:
             ],
             needs_mypy_plugins=True,
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 137},
+            cost={"mypy": 137, "ty": 4},
         ),
         Project(
             location="https://github.com/google/jax",
@@ -483,7 +483,7 @@ def get_projects() -> list[Project]:
             paths=["jax"],
             deps=["ml_dtypes", "numpy", "scipy-stubs", "types-requests"],
             expected_success=("mypy",),
-            cost={"mypy": 316, "pyright": 90},
+            cost={"mypy": 316, "pyright": 90, "ty": 7},
         ),
         Project(
             location="https://github.com/dulwich/dulwich",
@@ -492,7 +492,7 @@ def get_projects() -> list[Project]:
             paths=["dulwich"],
             deps=["types-certifi", "types-paramiko", "types-requests"],
             expected_success=("mypy",),
-            cost={"mypy": 34},
+            cost={"mypy": 34, "ty": 3},
         ),
         Project(
             location="https://github.com/optuna/optuna",
@@ -511,7 +511,7 @@ def get_projects() -> list[Project]:
                 "typing-extensions",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 117, "pyright": 70},
+            cost={"mypy": 117, "pyright": 70, "ty": 2},
         ),
         Project(
             location="https://github.com/trailofbits/manticore",
@@ -519,7 +519,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["types-protobuf", "types-PyYAML", "types-redis", "types-setuptools"],
             expected_success=("mypy",),
-            cost={"mypy": 79, "pyright": 75},
+            cost={"mypy": 79, "pyright": 75, "ty": 21},
         ),
         Project(
             location="https://github.com/aiortc/aiortc",
@@ -528,7 +528,7 @@ def get_projects() -> list[Project]:
             paths=["src"],
             deps=["cryptography", "types-pyOpenSSL"],
             expected_success=("mypy",),
-            cost={"mypy": 17},
+            cost={"mypy": 17, "ty": 1},
         ),
         Project(
             location="https://github.com/Textualize/rich",
@@ -536,7 +536,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["attrs"],
             expected_success=("mypy",),
-            cost={"mypy": 19},
+            cost={"mypy": 19, "ty": 1},
         ),
         Project(
             location="https://github.com/dedupeio/dedupe",
@@ -546,7 +546,7 @@ def get_projects() -> list[Project]:
             deps=["numpy"],
             needs_mypy_plugins=True,
             expected_success=("mypy",),
-            cost={"mypy": 35},
+            cost={"mypy": 35, "ty": 1},
         ),
         Project(
             location="https://github.com/schemathesis/schemathesis",
@@ -555,7 +555,7 @@ def get_projects() -> list[Project]:
             paths=["src/schemathesis"],
             deps=["attrs", "types-requests", "types-PyYAML", "hypothesis"],
             expected_success=("mypy",),
-            cost={"mypy": 33},
+            cost={"mypy": 33, "ty": 2},
             supported_platforms=["linux", "darwin"],
         ),
         Project(
@@ -565,7 +565,7 @@ def get_projects() -> list[Project]:
             paths=["src", "tests"],
             deps=["pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 56},
+            cost={"mypy": 56, "ty": 2},
         ),
         Project(
             location="https://github.com/Legrandin/pycryptodome",
@@ -574,7 +574,7 @@ def get_projects() -> list[Project]:
             paths=["lib"],
             deps=["pycryptodome-test-vectors"],
             expected_success=("mypy",),
-            cost={"mypy": 17},
+            cost={"mypy": 17, "ty": 2},
         ),
         Project(
             location="https://github.com/niklasf/python-chess",
@@ -582,7 +582,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["chess"],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 19},
+            cost={"mypy": 19, "ty": 1},
         ),
         Project(
             location="https://github.com/pytorch/ignite",
@@ -590,14 +590,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["packaging"],
             expected_success=("mypy",),
-            cost={"pyright": 50, "mypy": 19},
+            cost={"pyright": 50, "mypy": 19, "ty": 2},
         ),
         Project(
             location="https://github.com/pytorch/vision",
             mypy_cmd=None,
             pyright_cmd="{pyright}",
             deps=["numpy", "pillow"],
-            cost={"pyright": 50},
+            cost={"pyright": 50, "ty": 3},
         ),
         Project(
             location="https://github.com/pypa/packaging",
@@ -605,7 +605,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
             expected_success=("mypy",),
-            cost={"mypy": 9},
+            cost={"mypy": 9, "ty": 1},
         ),
         Project(
             location="https://github.com/pydantic/pydantic",
@@ -614,7 +614,7 @@ def get_projects() -> list[Project]:
             paths=["pydantic"],
             deps=["annotated-types", "pydantic-core", "typing-extensions", "typing-inspection"],
             expected_success=("mypy",),
-            cost={"mypy": 29},
+            cost={"mypy": 29, "ty": 5},
         ),
         Project(
             location="https://github.com/encode/starlette",
@@ -623,7 +623,7 @@ def get_projects() -> list[Project]:
             paths=["starlette", "tests"],
             deps=["anyio", "types-requests", "types-PyYAML"],
             expected_success=("mypy",),
-            cost={"mypy": 41},
+            cost={"mypy": 41, "ty": 1},
         ),
         Project(
             location="https://github.com/aio-libs/janus",
@@ -631,7 +631,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["janus"],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 10},
+            cost={"mypy": 10, "ty": 1},
         ),
         Project(
             location="https://github.com/alerta/alerta",
@@ -640,7 +640,7 @@ def get_projects() -> list[Project]:
             paths=["alerta", "tests"],
             deps=["types-PyYAML", "types-setuptools", "types-requests", "types-pytz"],
             expected_success=("mypy",),
-            cost={"mypy": 21},
+            cost={"mypy": 21, "ty": 1},
         ),
         Project(
             location="https://github.com/nolar/kopf",
@@ -649,7 +649,7 @@ def get_projects() -> list[Project]:
             paths=["kopf"],
             deps=["types-setuptools", "types-PyYAML"],
             expected_success=("mypy",),
-            cost={"mypy": 19},
+            cost={"mypy": 19, "ty": 1},
         ),
         Project(
             location="https://github.com/davidhalter/parso",
@@ -657,7 +657,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["parso"],
             expected_success=("mypy",),
-            cost={"pyright": 75, "mypy": 10},
+            cost={"pyright": 75, "mypy": 10, "ty": 2},
         ),
         Project(
             location="https://github.com/konradhalas/dacite",
@@ -665,14 +665,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["dacite"],
             expected_success=("mypy",),
-            cost={"mypy": 7},
+            cost={"mypy": 7, "ty": 1},
         ),
         Project(
             location="https://github.com/ilevkivskyi/com2ann",
             mypy_cmd="{mypy} --python-version=3.9 src/com2ann.py src/test_com2ann.py",
             pyright_cmd="{pyright}",
             expected_success=("mypy",),
-            cost={"mypy": 10},
+            cost={"mypy": 10, "ty": 1},
         ),
         Project(
             location="https://github.com/srittau/python-htmlgen",
@@ -681,7 +681,7 @@ def get_projects() -> list[Project]:
             paths=["htmlgen", "test_htmlgen"],
             deps=["asserts"],
             expected_success=("mypy",),
-            cost={"mypy": 13},
+            cost={"mypy": 13, "ty": 1},
         ),
         Project(
             location="https://github.com/mitmproxy/mitmproxy",
@@ -690,7 +690,7 @@ def get_projects() -> list[Project]:
             paths=["."],
             deps=["types-requests", "types-pyOpenSSL"],
             expected_success=("mypy",),
-            cost={"mypy": 41},
+            cost={"mypy": 41, "ty": 3},
         ),
         Project(
             location="https://github.com/jpadilla/pyjwt",
@@ -699,7 +699,7 @@ def get_projects() -> list[Project]:
             paths=["jwt"],
             deps=["cryptography"],
             expected_success=("mypy",),
-            cost={"mypy": 11},
+            cost={"mypy": 11, "ty": 1},
         ),
         Project(
             location="https://github.com/apache/spark",
@@ -715,7 +715,7 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["paroxython"],
-            cost={"mypy": 9},
+            cost={"mypy": 9, "ty": 1},
         ),
         Project(
             location="https://github.com/Akuli/porcupine",
@@ -733,7 +733,7 @@ def get_projects() -> list[Project]:
                 "types-tree-sitter",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 23},
+            cost={"mypy": 23, "ty": 1},
         ),
         Project(
             location="https://github.com/dropbox/mypy-protobuf",
@@ -741,14 +741,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["types-protobuf"],
             expected_success=("mypy",),
-            cost={"mypy": 9},
+            cost={"mypy": 9, "ty": 1},
         ),
         Project(
             location="https://github.com/spack/spack",
             mypy_cmd="{mypy} -p spack -p llnl",
             pyright_cmd="{pyright}",
             expected_success=("mypy",),
-            cost={"mypy": 65, "pyright": 100},
+            cost={"mypy": 65, "pyright": 100, "ty": 7},
         ),
         Project(
             location="https://github.com/johtso/httpx-caching",
@@ -757,14 +757,14 @@ def get_projects() -> list[Project]:
             paths=["."],
             deps=["types-freezegun", "types-mock", "httpx", "anyio", "pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 40},
+            cost={"mypy": 40, "ty": 1},
         ),
         Project(
             location="https://github.com/python-poetry/poetry",
             mypy_cmd="{mypy}",
             pyright_cmd="{pyright}",
             deps=["types-requests", "pytest"],
-            cost={"mypy": 63},
+            cost={"mypy": 63, "ty": 2},
         ),
         Project(
             location="https://github.com/awslabs/sockeye",
@@ -772,7 +772,7 @@ def get_projects() -> list[Project]:
             pyright_cmd=None,
             deps=["types-PyYAML"],
             expected_success=("mypy",),
-            cost={"mypy": 16},
+            cost={"mypy": 16, "ty": 1},
         ),
         Project(
             location="https://github.com/wntrblm/nox",
@@ -792,7 +792,7 @@ def get_projects() -> list[Project]:
                 "uv",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 18},
+            cost={"mypy": 18, "ty": 1},
         ),
         Project(
             location="https://github.com/pandera-dev/pandera",
@@ -812,14 +812,14 @@ def get_projects() -> list[Project]:
                 "typing-inspect",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 194},
+            cost={"mypy": 194, "ty": 8},
         ),
         Project(
             location="https://gitlab.com/cki-project/cki-lib",
             mypy_cmd="{mypy} --strict .",
             pyright_cmd="{pyright}",
             deps=["types-PyYAML", "cibuildwheel", "types-requests"],
-            cost={"mypy": 20},
+            cost={"mypy": 20, "ty": 1},
         ),
         Project(
             location="https://github.com/python-jsonschema/check-jsonschema",
@@ -828,7 +828,7 @@ def get_projects() -> list[Project]:
             paths=["src"],
             deps=["types-jsonschema", "types-requests"],
             expected_success=("mypy",),
-            cost={"mypy": 13},
+            cost={"mypy": 13, "ty": 1},
         ),
         Project(
             location="https://github.com/pybind/pybind11",
@@ -836,7 +836,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["nox", "rich", "types-setuptools"],
             expected_success=("mypy",),
-            cost={"mypy": 19},
+            cost={"mypy": 19, "ty": 1},
         ),
         Project(
             location="https://github.com/rpdelaney/downforeveryone",
@@ -845,7 +845,7 @@ def get_projects() -> list[Project]:
             paths=["."],
             deps=["types-requests", "pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 21},
+            cost={"mypy": 21, "ty": 1},
         ),
         Project(
             location="https://github.com/DataDog/dd-trace-py",
@@ -863,7 +863,7 @@ def get_projects() -> list[Project]:
             ],
             needs_mypy_plugins=True,
             expected_success=("mypy",),
-            cost={"pyright": 75, "mypy": 49},
+            cost={"pyright": 75, "mypy": 49, "ty": 11},
         ),
         Project(
             location="https://github.com/systemd/mkosi",
@@ -872,7 +872,7 @@ def get_projects() -> list[Project]:
             paths=["mkosi"],
             deps=["cryptography"],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 23},
+            cost={"mypy": 23, "ty": 2},
         ),
         Project(
             location="https://github.com/sympy/sympy",
@@ -881,14 +881,14 @@ def get_projects() -> list[Project]:
             paths=["sympy"],
             deps=["mpmath"],
             expected_success=("mypy",),
-            cost={"mypy": 182, "pyright": 240},
+            cost={"mypy": 182, "pyright": 240, "ty": 20},
         ),
         Project(
             location="https://github.com/nion-software/nionutils",
             mypy_cmd="{mypy} --strict -p nion.utils --config-file=",
             pyright_cmd="{pyright}",
             expected_success=("mypy",),
-            cost={"mypy": 14},
+            cost={"mypy": 14, "ty": 1},
         ),
         Project(
             location="https://github.com/PyCQA/flake8-pyi",
@@ -897,7 +897,7 @@ def get_projects() -> list[Project]:
             paths=["flake8_pyi"],
             deps=["types-pyflakes"],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 9},
+            cost={"mypy": 9, "ty": 1},
         ),
         Project(
             location="https://github.com/internetarchive/openlibrary",
@@ -912,7 +912,7 @@ def get_projects() -> list[Project]:
                 "types-Deprecated",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 34},
+            cost={"mypy": 34, "ty": 2},
         ),
         Project(
             location="https://github.com/JohannesBuchner/imagehash",
@@ -921,7 +921,7 @@ def get_projects() -> list[Project]:
             paths=["imagehash"],
             deps=["PyWavelets", "numpy", "scipy-stubs", "types-Pillow"],
             expected_success=("mypy",),
-            cost={"mypy": 96},
+            cost={"mypy": 96, "ty": 1},
         ),
         Project(
             location="https://github.com/Kalmat/PyWinCtl",
@@ -929,7 +929,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src/pywinctl"],
             deps=["types-setuptools", "types-pywin32", "types-python-xlib"],
-            cost={"mypy": 14},
+            cost={"mypy": 14, "ty": 1},
         ),
         Project(
             location="https://github.com/mesonbuild/meson",
@@ -937,7 +937,7 @@ def get_projects() -> list[Project]:
             pyright_cmd=None,
             deps=["types-PyYAML", "coverage", "types-chevron", "types-PyYAML", "types-tqdm"],
             expected_success=("mypy",),
-            cost={"mypy": 67},
+            cost={"mypy": 67, "ty": 5},
         ),
         Project(
             location="https://github.com/aio-libs/aiohttp-devtools",
@@ -945,7 +945,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["aiohttp", "watchfiles", "types-pygments"],
             expected_success=("mypy",),
-            cost={"mypy": 41},
+            cost={"mypy": 41, "ty": 1},
         ),
         Project(
             location="https://github.com/sco1/pylox",
@@ -954,7 +954,7 @@ def get_projects() -> list[Project]:
             paths=["."],
             deps=["attrs", "pytest"],
             expected_success=("mypy",),
-            cost={"mypy": 21},
+            cost={"mypy": 21, "ty": 1},
             min_python_version=(3, 10),
         ),
         Project(
@@ -964,7 +964,7 @@ def get_projects() -> list[Project]:
             paths=["ppb_vector", "tests"],
             deps=["hypothesis"],
             expected_success=("mypy",),
-            cost={"mypy": 20},
+            cost={"mypy": 20, "ty": 1},
             min_python_version=(3, 10),
         ),
         Project(
@@ -986,7 +986,7 @@ def get_projects() -> list[Project]:
                 "packaging",
             ],
             expected_success=("mypy",),
-            cost={"mypy": 26},
+            cost={"mypy": 26, "ty": 1},
         ),
         Project(
             location="https://github.com/astropenguin/xarray-dataclasses",
@@ -995,7 +995,7 @@ def get_projects() -> list[Project]:
             paths=["xarray_dataclasses"],
             deps=["numpy", "xarray"],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 7},
+            cost={"mypy": 7, "ty": 2},
         ),
         Project(
             location="https://github.com/scipy/scipy-stubs",
@@ -1012,7 +1012,7 @@ def get_projects() -> list[Project]:
                 "scipy",
             ],
             expected_success=("mypy", "pyright", "pyrefly"),
-            cost={"mypy": 294},
+            cost={"mypy": 294, "ty": 5},
         ),
         Project(
             location="https://github.com/typeddjango/django-stubs",
@@ -1022,7 +1022,7 @@ def get_projects() -> list[Project]:
             deps=["asgiref", "django-stubs-ext", "django", "redis", "tomli", "types-PyYAML"],
             needs_mypy_plugins=True,
             expected_success=("mypy",),
-            cost={"mypy": 32},
+            cost={"mypy": 32, "ty": 3},
         ),
         Project(
             location="https://github.com/pyppeteer/pyppeteer",
@@ -1030,14 +1030,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["pyppeteer"],
             install_cmd="{install} .",
-            cost={"mypy": 17},
+            cost={"mypy": 17, "ty": 1},
         ),
         Project(
             location="https://github.com/pypa/pip",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
-            cost={"pyright": 45, "mypy": 36},
+            cost={"pyright": 45, "mypy": 36, "ty": 4},
         ),
         Project(
             location="https://github.com/tornadoweb/tornado",
@@ -1045,7 +1045,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["tornado"],
             deps=["types-contextvars", "types-pycurl"],
-            cost={"mypy": 40},
+            cost={"mypy": 40, "ty": 2},
         ),
         Project(
             location="https://github.com/scipy/scipy",
@@ -1053,7 +1053,7 @@ def get_projects() -> list[Project]:
             pyright_cmd=None,
             deps=["numpy", "pytest", "hypothesis", "setuptools>=71.1", "types-psutil"],
             needs_mypy_plugins=True,
-            cost={"mypy": 133},
+            cost={"mypy": 133, "ty": 25},
         ),
         Project(
             location="https://github.com/pycqa/flake8",
@@ -1061,7 +1061,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src", "tests"],
             deps=["pytest"],
-            cost={"mypy": 22},
+            cost={"mypy": 22, "ty": 1},
         ),
         Project(
             location="https://github.com/home-assistant/core",
@@ -1084,14 +1084,14 @@ def get_projects() -> list[Project]:
                 "voluptuous",
             ],
             needs_mypy_plugins=True,
-            cost={"mypy": 411, "pyright": 240},
+            cost={"mypy": 411, "pyright": 240, "ty": 30},
         ),
         Project(
             location="https://github.com/kornia/kornia",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["kornia"],
-            cost={"mypy": 31},
+            cost={"mypy": 31, "ty": 2},
         ),
         Project(
             location="https://github.com/ibis-project/ibis",
@@ -1109,7 +1109,7 @@ def get_projects() -> list[Project]:
                 "types-requests",
                 "types-setuptools",
             ],
-            cost={"mypy": 101, "pyright": 60},
+            cost={"mypy": 101, "pyright": 60, "ty": 4},
         ),
         Project(
             location="https://github.com/streamlit/streamlit",
@@ -1130,7 +1130,7 @@ def get_projects() -> list[Project]:
                 "click",
                 "pytest",
             ],
-            cost={"mypy": 0, "pyright": 50},
+            cost={"mypy": 0, "pyright": 50, "ty": 2},
         ),
         Project(
             location="https://github.com/dragonchain/dragonchain",
@@ -1138,7 +1138,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["dragonchain"],
             deps=["types-redis", "types-requests"],
-            cost={"mypy": 26},
+            cost={"mypy": 26, "ty": 1},
         ),
         Project(
             location="https://github.com/rotki/rotki",
@@ -1146,7 +1146,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["rotkehlchen"],
             deps=["eth-typing", "types-requests", "types-setuptools"],
-            cost={"pyright": 60, "mypy": 9},
+            cost={"pyright": 60, "mypy": 9, "ty": 6},
         ),
         Project(
             location="https://github.com/arviz-devs/arviz",
@@ -1154,7 +1154,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             deps=["numpy", "pytest", "scipy-stubs", "types-setuptools", "types-ujson", "xarray"],
-            cost={"pyright": 45, "mypy": 78},
+            cost={"pyright": 45, "mypy": 78, "ty": 2},
         ),
         Project(
             location="https://github.com/urllib3/urllib3",
@@ -1170,7 +1170,7 @@ def get_projects() -> list[Project]:
                 "types-backports",
                 "types-requests",
             ],
-            cost={"mypy": 35},
+            cost={"mypy": 35, "ty": 1},
         ),
         Project(
             location="https://github.com/common-workflow-language/schema_salad",
@@ -1178,7 +1178,7 @@ def get_projects() -> list[Project]:
             pyright_cmd=None,
             install_cmd="{install} $(grep -v mypy mypy-requirements.txt) -r requirements.txt",
             expected_success=("mypy",),
-            cost={"mypy": 33},
+            cost={"mypy": 33, "ty": 1},
             supported_platforms=["linux", "darwin"],
         ),
         Project(
@@ -1192,7 +1192,7 @@ def get_projects() -> list[Project]:
             # install_cmd="{install} -r mypy-requirements.txt -r requirements.txt",
             install_cmd="{install} $(grep -v -e 'mypy' -e ';' mypy-requirements.txt) -r requirements.txt",
             expected_success=("mypy",),
-            cost={"mypy": 99},
+            cost={"mypy": 99, "ty": 2},
             supported_platforms=["linux", "darwin"],
         ),
         Project(
@@ -1209,14 +1209,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["tanjun"],
             deps=["hikari", "alluka"],
-            cost={"mypy": 46},
+            cost={"mypy": 46, "ty": 1},
         ),
         Project(
             location="https://github.com/joerick/pyinstrument",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["pyinstrument"],
-            cost={"mypy": 13},
+            cost={"mypy": 13, "ty": 1},
         ),
         Project(
             location="https://github.com/Gobot1234/steam.py",
@@ -1233,7 +1233,7 @@ def get_projects() -> list[Project]:
             paths=["alectryon.py"],
             deps=["types-docutils"],
             expected_success=("pyright",),
-            cost={"mypy": 14},
+            cost={"mypy": 14, "ty": 1},
         ),
         Project(
             location="https://github.com/yurijmikhalevich/rclip",
@@ -1241,14 +1241,14 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["rclip"],
             deps=["numpy", "types-Pillow", "types-requests", "types-tqdm"],
-            cost={"mypy": 27},
+            cost={"mypy": 27, "ty": 1},
         ),
         Project(
             location="https://github.com/psycopg/psycopg",
             mypy_cmd="{mypy}",
             pyright_cmd="{pyright}",
             deps=["pytest", "pproxy"],
-            cost={"mypy": 45},
+            cost={"mypy": 45, "ty": 2},
         ),
         Project(
             location="https://gitlab.com/dkg/python-sop",
@@ -1256,7 +1256,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["sop"],
             expected_success=("pyright",),
-            cost={"mypy": 8},
+            cost={"mypy": 8, "ty": 1},
         ),
         Project(
             location="https://github.com/Rapptz/discord.py",
@@ -1265,7 +1265,7 @@ def get_projects() -> list[Project]:
             paths=["discord"],
             deps=["types-requests", "types-setuptools", "aiohttp"],
             expected_success=("pyright",),
-            cost={"mypy": 63},
+            cost={"mypy": 63, "ty": 3},
         ),
         Project(
             location="https://github.com/canonical/cloud-init",
@@ -1280,7 +1280,7 @@ def get_projects() -> list[Project]:
                 "types-requests",
                 "types-setuptools",
             ],
-            cost={"mypy": 72, "pyright": 50},
+            cost={"mypy": 72, "pyright": 50, "ty": 4},
         ),
         Project(
             location="https://github.com/mongodb/mongo-python-driver",
@@ -1288,7 +1288,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["bson", "gridfs", "tools", "pymongo"],
             deps=["types-requests", "types-pyOpenSSL", "cryptography", "certifi"],
-            cost={"mypy": 36},
+            cost={"mypy": 36, "ty": 2},
         ),
         Project(
             location="https://github.com/artigraph/artigraph",
@@ -1296,7 +1296,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright}",
             deps=["pydantic", "numpy", "pytest"],
             needs_mypy_plugins=True,
-            cost={"mypy": 44},
+            cost={"mypy": 44, "ty": 1},
         ),
         Project(
             location="https://github.com/MaterializeInc/materialize",
@@ -1315,7 +1315,7 @@ def get_projects() -> list[Project]:
                 "pyarrow-stubs",
                 "pyarrow",
             ],
-            cost={"mypy": 109},
+            cost={"mypy": 109, "ty": 3},
         ),
         Project(
             location="https://github.com/canonical/operator",
@@ -1323,7 +1323,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["ops"],
             deps=["types-PyYAML"],
-            cost={"mypy": 18},
+            cost={"mypy": 18, "ty": 1},
         ),
         Project(
             location="https://github.com/caronc/apprise",
@@ -1340,7 +1340,7 @@ def get_projects() -> list[Project]:
                 "certifi",
                 "babel",
             ],
-            cost={"mypy": 50},
+            cost={"mypy": 50, "ty": 3},
         ),
         Project(
             location="https://github.com/Finistere/antidote",
@@ -1348,7 +1348,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             deps=["pytest"],
-            cost={"mypy": 31},
+            cost={"mypy": 31, "ty": 1},
         ),
         Project(
             location="https://github.com/cognitedata/Expression",
@@ -1356,7 +1356,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             deps=["pytest"],
-            cost={"mypy": 25},
+            cost={"mypy": 25, "ty": 1},
         ),
         Project(
             location="https://github.com/pyodide/pyodide",
@@ -1372,7 +1372,7 @@ def get_projects() -> list[Project]:
                 "pydantic",
             ],
             needs_mypy_plugins=True,
-            cost={"mypy": 26},
+            cost={"mypy": 26, "ty": 2},
         ),
         Project(
             location="https://github.com/bokeh/bokeh",
@@ -1380,7 +1380,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src", "release"],
             deps=["types-boto", "tornado", "numpy", "jinja2", "selenium"],
-            cost={"pyright": 60, "mypy": 65},
+            cost={"pyright": 60, "mypy": 65, "ty": 3},
         ),
         Project(
             location="https://github.com/pandas-dev/pandas-stubs",
@@ -1398,7 +1398,7 @@ def get_projects() -> list[Project]:
                 "SQLAlchemy",
             ],
             expected_success=("pyright",),
-            cost={"mypy": 355, "pyright": 75},
+            cost={"mypy": 355, "pyright": 75, "ty": 118},
         ),
         Project(
             location="https://github.com/enthought/comtypes",
@@ -1406,7 +1406,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["comtypes"],
             deps=["numpy"],
-            cost={"mypy": 34},
+            cost={"mypy": 34, "ty": 1},
         ),
         Project(
             location="https://github.com/mit-ll-responsible-ai/hydra-zen",
@@ -1414,7 +1414,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src", "tests/annotations"],
             deps=["pydantic", "beartype", "hydra-core"],
-            cost={"mypy": 70},
+            cost={"mypy": 70, "ty": 1},
         ),
         Project(
             location="https://github.com/Toufool/AutoSplit",
@@ -1438,7 +1438,7 @@ def get_projects() -> list[Project]:
                 "types-requests",
                 "types-toml",
             ],
-            cost={"mypy": 51},
+            cost={"mypy": 51, "ty": 1},
         ),
         Project(
             location="https://github.com/Avasam/speedrun.com_global_scoreboard_webapp",
@@ -1453,7 +1453,7 @@ def get_projects() -> list[Project]:
                 "types-httplib2",
                 "types-requests",
             ],
-            cost={"mypy": 35},
+            cost={"mypy": 35, "ty": 1},
         ),
         Project(
             location="https://github.com/pwndbg/pwndbg",
@@ -1461,7 +1461,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["pwndbg"],
             deps=["types-gdb"],
-            cost={"mypy": 44, "pyright": 75},
+            cost={"mypy": 44, "pyright": 75, "ty": 3},
         ),
         Project(
             location="https://github.com/keithasaurus/koda-validate",
@@ -1469,7 +1469,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["koda_validate"],
             deps=["koda"],
-            cost={"mypy": 18},
+            cost={"mypy": 18, "ty": 1},
         ),
         Project(
             location="https://github.com/python/cpython",
@@ -1478,7 +1478,7 @@ def get_projects() -> list[Project]:
             paths=["Tools/clinic"],
             name_override="CPython (Argument Clinic)",
             pyright_cmd=None,
-            cost={"mypy": 10},
+            cost={"mypy": 10, "ty": 1},
         ),
         Project(
             location="https://github.com/python/cpython",
@@ -1487,7 +1487,7 @@ def get_projects() -> list[Project]:
             paths=["Tools/cases_generator"],
             name_override="CPython (cases_generator)",
             pyright_cmd=None,
-            cost={"mypy": 10},
+            cost={"mypy": 10, "ty": 1},
         ),
         Project(
             location="https://github.com/python/cpython",
@@ -1497,7 +1497,7 @@ def get_projects() -> list[Project]:
             name_override="CPython (peg_generator)",
             pyright_cmd=None,
             deps=["types-setuptools", "types-psutil"],
-            cost={"mypy": 10},
+            cost={"mypy": 10, "ty": 1},
         ),
         Project(
             location="https://github.com/python-trio/trio",
@@ -1513,7 +1513,7 @@ def get_projects() -> list[Project]:
                 "pytest",
                 "sniffio",
             ],
-            cost={"mypy": 41},
+            cost={"mypy": 41, "ty": 2},
         ),
         Project(
             location="https://github.com/pypa/setuptools",
@@ -1522,13 +1522,13 @@ def get_projects() -> list[Project]:
             paths=["setuptools"],
             deps=["pytest", "filelock", "ini2toml", "packaging", "tomli", "tomli-w"],
             expected_success=("pyright",),
-            cost={"mypy": 31},
+            cost={"mypy": 31, "ty": 3},
         ),
         Project(
             location="https://github.com/detachhead/pytest-robotframework",
             mypy_cmd="{mypy} -p pytest_robotframework",
             pyright_cmd="{pyright}",
-            cost={"mypy": 4},
+            cost={"mypy": 4, "ty": 1},
         ),
         Project(
             location="https://github.com/mhammond/pywin32",
@@ -1537,14 +1537,14 @@ def get_projects() -> list[Project]:
             ty_cmd="{ty} check {paths} --exclude Pythonwin/pywin/test/_dbgscript.py",
             paths=["."],
             deps=["types-pywin32", "types-regex", "types-setuptools"],
-            cost={"mypy": 32},
+            cost={"mypy": 32, "ty": 4},
         ),
         Project(
             location="https://github.com/beartype/beartype",
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["beartype"],
-            cost={"mypy": 15},
+            cost={"mypy": 15, "ty": 1},
         ),
         Project(
             location="https://github.com/colour-science/colour",
@@ -1552,7 +1552,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["colour"],
             deps=["matplotlib", "numpy", "pandas-stubs", "pytest", "scipy-stubs"],
-            cost={"mypy": 464, "pyright": 180},
+            cost={"mypy": 464, "pyright": 180, "ty": 21},
         ),
         Project(
             location="https://github.com/vega/altair",
@@ -1570,7 +1570,7 @@ def get_projects() -> list[Project]:
                 "scipy-stubs",
                 "types-jsonschema",
             ],
-            cost={"mypy": 124},
+            cost={"mypy": 124, "ty": 3},
         ),
         Project(
             location="https://github.com/hydpy-dev/hydpy",
@@ -1578,7 +1578,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["hydpy"],
             deps=["numpy", "pandas-stubs", "scipy-stubs", "types-docutils", "types-networkx"],
-            cost={"mypy": 80},
+            cost={"mypy": 80, "ty": 4},
         ),
         Project(
             location="https://github.com/static-frame/static-frame",
@@ -1586,7 +1586,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["static_frame"],
             deps=["numpy", "arraykit==1.2.0"],
-            cost={"mypy": 280},
+            cost={"mypy": 280, "ty": 7},
         ),
         Project(
             location="https://github.com/mikeshardmind/async-utils",
@@ -1594,7 +1594,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
             expected_success=("pyright",),
-            cost={"mypy": 12},
+            cost={"mypy": 12, "ty": 1},
         ),
         Project(
             location="https://github.com/pypa/cibuildwheel",
@@ -1610,14 +1610,14 @@ def get_projects() -> list[Project]:
                 "platformdirs",
                 "uv",
             ],
-            cost={"mypy": 17},
+            cost={"mypy": 17, "ty": 1},
         ),
         Project(
             location="https://github.com/pypa/build",
             mypy_cmd="{mypy}",
             pyright_cmd="{pyright}",
             deps=["importlib_metadata", "packaging", "pyproject_hooks", "tomli", "uv"],
-            cost={"mypy": 11},
+            cost={"mypy": 11, "ty": 1},
         ),
         Project(
             location="https://github.com/pypa/pyproject-metadata",
@@ -1626,7 +1626,7 @@ def get_projects() -> list[Project]:
             paths=["pyproject_metadata"],
             deps=["packaging"],
             expected_success=("pyright",),
-            cost={"mypy": 9},
+            cost={"mypy": 9, "ty": 1},
         ),
         Project(
             location="https://github.com/strawberry-graphql/strawberry",
@@ -1634,7 +1634,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["strawberry"],
             deps=["graphql-core", "python-dateutil", "packaging"],
-            cost={"mypy": 25},
+            cost={"mypy": 25, "ty": 1},
         ),
         Project(
             location="https://github.com/archlinux/archinstall",
@@ -1642,7 +1642,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["."],
             deps=["cryptography", "pydantic", "pytest", "textual"],
-            cost={"mypy": 34},
+            cost={"mypy": 34, "ty": 2},
         ),
         Project(
             location="https://github.com/zopefoundation/zope.interface",
@@ -1650,7 +1650,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
             deps=["zope.testing"],
-            cost={"mypy": 15},
+            cost={"mypy": 15, "ty": 1},
         ),
         Project(
             location="https://github.com/scikit-build/scikit-build-core",
@@ -1676,7 +1676,7 @@ def get_projects() -> list[Project]:
                 "tomli",
                 "types-setuptools",
             ],
-            cost={"mypy": 38},
+            cost={"mypy": 38, "ty": 1},
         ),
         Project(
             location="https://github.com/hynek/svcs",
@@ -1685,7 +1685,7 @@ def get_projects() -> list[Project]:
             paths=["src", "tests/typing"],
             deps=["attrs", "flask", "aiohttp", "fastapi", "starlette"],
             expected_success=("mypy", "pyright"),
-            cost={"mypy": 57},
+            cost={"mypy": 57, "ty": 1},
         ),
         Project(
             location="https://github.com/glyph/DateType",
@@ -1693,7 +1693,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
             expected_success=("mypy",),
-            cost={"mypy": 6},
+            cost={"mypy": 6, "ty": 1},
         ),
         Project(
             location="https://github.com/egraphs-good/egglog-python",
@@ -1702,7 +1702,7 @@ def get_projects() -> list[Project]:
             paths=["python"],
             deps=["anywidget", "syrupy"],
             expected_success=("mypy",),
-            cost={"mypy": 6},
+            cost={"mypy": 6, "ty": 3},
         ),
         Project(
             location="https://github.com/WoLpH/numpy-stl",
@@ -1712,6 +1712,7 @@ def get_projects() -> list[Project]:
             paths=["stl"],
             deps=["numpy", "python-utils"],
             expected_success=("mypy", "pyright", "pyrefly"),
+            cost={"ty": 2},
         ),
         Project(
             location="https://github.com/pyca/cryptography",
@@ -1719,6 +1720,7 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["src/cryptography", "tests"],
             deps=["cffi", "typing-extensions", "pytest"],
+            cost={"ty": 2},
         ),
         Project(
             location="https://gitlab.com/TTsangSC/pytest-autoprofile",


### PR DESCRIPTION
When we run ecosystem-analyzer in CI for ty, we shard the workflow between several runners. But the sharding could be more effective: some shards take longer than others (especially when [more shards](https://github.com/astral-sh/ruff/pull/24893) are added) because they have projects in them that are more expensive to analyze.

Whem mypy_primer is sharded in typeshed's or mypy's CI, projects are distributed between the shards usimg the `cost` value. ty's ecosystem-analyzer tool is a wrapper around mypy_primer, so if we add similar `cost` values for ty here, we should be able to use this data in ecosystem-analyzer to similarly distribute projects more effectively across the shards in ty's CI.

The `cost` values added in this PR are based on the timing report from a recent run of ecosystem-analyzer in ty's CI.