### PR TITLE
setuptool's distutils is py.typed, use more `setuptools` directly

### DIFF
--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -69,7 +69,14 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} --config-file mypy_self_check.ini --num-workers=0 -p mypy -p mypyc",
             pyright_cmd="{pyright} {paths}",
             paths=["mypy", "mypyc"],
-            deps=["pytest", "types-psutil", "types-setuptools", "filelock", "tomli"],
+            deps=[
+                "pytest",
+                "types-psutil",
+                "types-setuptools",
+                "setuptools>=83",  # For distutils --> setuptools._distutils alias
+                "filelock",
+                "tomli",
+            ],
             expected_success=("mypy",),
             cost={"mypy": 82, "pyright": 50, "ty": 10},
         ),
@@ -492,7 +499,10 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} {paths} --ignore-missing-imports",
             pyright_cmd="{pyright} {paths}",
             paths=["aioredis"],
-            deps=["async-timeout"],
+            deps=[
+                "async-timeout" "types-setuptools",
+                "setuptools>=83",  # For distutils --> setuptools._distutils alias
+            ],
             cost={"mypy": 14, "ty": 1},
         ),
         Project(
@@ -1143,6 +1153,10 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} {paths}",
             pyright_cmd="{pyright} {paths}",
             paths=["src"],
+            deps=[
+                "types-setuptools",
+                "setuptools>=83",  # For distutils --> setuptools._distutils alias
+            ],
             cost={"pyright": 45, "mypy": 36, "ty": 4},
         ),
         Project(
@@ -1539,7 +1553,11 @@ def get_projects() -> list[Project]:
             mypy_cmd="{mypy} {paths} --platform win32",
             pyright_cmd="{pyright} {paths}",
             paths=["comtypes"],
-            deps=["numpy"],
+            deps=[
+                "numpy",
+                "types-setuptools",
+                "setuptools>=83",  # For distutils --> setuptools._distutils alias
+            ],
             cost={"mypy": 34, "ty": 1},
         ),
         Project(

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -500,7 +500,8 @@ def get_projects() -> list[Project]:
             pyright_cmd="{pyright} {paths}",
             paths=["aioredis"],
             deps=[
-                "async-timeout" "types-setuptools",
+                "async-timeout",
+                "types-setuptools",
                 "setuptools>=83",  # For distutils --> setuptools._distutils alias
             ],
             cost={"mypy": 14, "ty": 1},

--- a/mypy_primer/projects.py
+++ b/mypy_primer/projects.py
@@ -961,6 +961,7 @@ def get_projects() -> list[Project]:
                 "attrs",
                 "types-six",
                 "types-setuptools",
+                "setuptools",  # For distutils --> setuptools._distutils alias
                 "types-docutils",
                 "types-PyYAML",
                 "types-protobuf",


### PR DESCRIPTION
I'm not even certain, but I *think* this should resolve mypy_primer issue in https://github.com/python/typeshed/pull/13627#issuecomment-4883345452 ?